### PR TITLE
Switched to only support querying for single items by identifiers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.1.1.RELEASE'
+        springBootVersion = '2.1.2.RELEASE'
     }
     repositories {
         jcenter()
@@ -39,13 +39,14 @@ lombokVersion = '1.18.4'
 spockSpringVersion = '1.2-RC3-groovy-2.5'
 
 dependencies {
+    compile('no.fint:fint-model-resource:0.3.3')
     compile("no.fint:fint-utdanning-resource-model-java:${apiVersion}")
     compile("no.fint:fint-administrasjon-resource-model-java:${apiVersion}")
 
     compile('com.graphql-java-kickstart:graphql-spring-boot-starter:5.4')
     compile('com.graphql-java-kickstart:graphiql-spring-boot-starter:5.4')
     compile('com.graphql-java-kickstart:graphql-java-tools:5.4.1')
-    compile('com.zhokhov.graphql:graphql-datetime-spring-boot-starter:1.3.0')
+    compile('com.zhokhov.graphql:graphql-datetime-spring-boot-starter:1.4.0')
 
     compile('org.springframework.boot:spring-boot-starter-webflux')
     compile('org.springframework.boot:spring-boot-starter')

--- a/src/main/java/no/fint/graphql/WebClientRequest.java
+++ b/src/main/java/no/fint/graphql/WebClientRequest.java
@@ -4,9 +4,11 @@ import graphql.schema.DataFetchingEnvironment;
 import graphql.servlet.GraphQLContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriBuilder;
+import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.util.function.Function;
@@ -33,6 +35,7 @@ public class WebClientRequest {
             request.header(HttpHeaders.AUTHORIZATION, token);
         }
         return request.retrieve()
+                .onStatus(HttpStatus::is4xxClientError, r -> Mono.empty())
                 .bodyToMono(type)
                 .block();
     }

--- a/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.ansvar;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.kodeverk.AnsvarResource;
-import no.fint.model.resource.administrasjon.kodeverk.AnsvarResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonAnsvarQueryResolver")
 public class AnsvarQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class AnsvarQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private AnsvarService service;
 
-    public List<AnsvarResource> getAnsvar(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        AnsvarResources resources = service.getAnsvarResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public AnsvarResource getAnsvar(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getAnsvarResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarResolver.java
@@ -4,30 +4,26 @@ package no.fint.graphql.model.administrasjon.ansvar;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.ansvar.AnsvarService;
 import no.fint.graphql.model.administrasjon.organisasjonselement.OrganisasjonselementService;
 import no.fint.graphql.model.administrasjon.fullmakt.FullmaktService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.kodeverk.AnsvarResource;
-
-
 import no.fint.model.resource.administrasjon.kodeverk.AnsvarResource;
 import no.fint.model.resource.administrasjon.organisasjon.OrganisasjonselementResource;
 import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("administrasjonAnsvarResolver")
 public class AnsvarResolver implements GraphQLResolver<AnsvarResource> {
-
 
     @Autowired
     private AnsvarService ansvarService;
@@ -40,27 +36,35 @@ public class AnsvarResolver implements GraphQLResolver<AnsvarResource> {
 
 
     public AnsvarResource getOverordnet(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
-        return ansvarService.getAnsvarResource(
-            Links.get(ansvar.getOverordnet()),
-            dfe);
+        return ansvar.getOverordnet()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> ansvarService.getAnsvarResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public AnsvarResource getUnderordnet(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
-        return ansvarService.getAnsvarResource(
-            Links.get(ansvar.getUnderordnet()),
-            dfe);
+    public List<AnsvarResource> getUnderordnet(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
+        return ansvar.getUnderordnet()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> ansvarService.getAnsvarResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public OrganisasjonselementResource getOrganisasjonselement(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
-        return organisasjonselementService.getOrganisasjonselementResource(
-            Links.get(ansvar.getOrganisasjonselement()),
-            dfe);
+    public List<OrganisasjonselementResource> getOrganisasjonselement(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
+        return ansvar.getOrganisasjonselement()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public FullmaktResource getFullmakt(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
-        return fullmaktService.getFullmaktResource(
-            Links.get(ansvar.getFullmakt()),
-            dfe);
+    public List<FullmaktResource> getFullmakt(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
+        return ansvar.getFullmakt()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> fullmaktService.getFullmaktResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarResolver.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("administrasjonAnsvarResolver")
@@ -37,34 +38,38 @@ public class AnsvarResolver implements GraphQLResolver<AnsvarResource> {
 
     public AnsvarResource getOverordnet(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
         return ansvar.getOverordnet()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> ansvarService.getAnsvarResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> ansvarService.getAnsvarResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<AnsvarResource> getUnderordnet(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
         return ansvar.getUnderordnet()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> ansvarService.getAnsvarResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> ansvarService.getAnsvarResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<OrganisasjonselementResource> getOrganisasjonselement(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
         return ansvar.getOrganisasjonselement()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<FullmaktResource> getFullmakt(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
         return ansvar.getFullmakt()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> fullmaktService.getFullmaktResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.ansvar;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.AnsvarResource;
-import no.fint.model.resource.administrasjon.kodeverk.AnsvarResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class AnsvarService {
     @Autowired
     private Endpoints endpoints;
 
-    public AnsvarResources getAnsvarResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonKodeverk() + "/ansvar",
-                    sinceTimeStamp),
-                AnsvarResources.class,
-                dfe);
+    public AnsvarResource getAnsvarResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getAnsvarResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/ansvar/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public AnsvarResource getAnsvarResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.arbeidsforhold;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.personal.ArbeidsforholdResource;
-import no.fint.model.resource.administrasjon.personal.ArbeidsforholdResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonArbeidsforholdQueryResolver")
 public class ArbeidsforholdQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class ArbeidsforholdQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ArbeidsforholdService service;
 
-    public List<ArbeidsforholdResource> getArbeidsforhold(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        ArbeidsforholdResources resources = service.getArbeidsforholdResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public ArbeidsforholdResource getArbeidsforhold(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getArbeidsforholdResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdResolver.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("administrasjonArbeidsforholdResolver")
@@ -62,74 +63,83 @@ public class ArbeidsforholdResolver implements GraphQLResolver<ArbeidsforholdRes
 
     public AnsvarResource getAnsvar(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
         return arbeidsforhold.getAnsvar()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> ansvarService.getAnsvarResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> ansvarService.getAnsvarResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public ArbeidsforholdstypeResource getArbeidsforholdstype(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
         return arbeidsforhold.getArbeidsforholdstype()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> arbeidsforholdstypeService.getArbeidsforholdstypeResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> arbeidsforholdstypeService.getArbeidsforholdstypeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public FunksjonResource getFunksjon(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
         return arbeidsforhold.getFunksjon()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> funksjonService.getFunksjonResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> funksjonService.getFunksjonResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public StillingskodeResource getStillingskode(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
         return arbeidsforhold.getStillingskode()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> stillingskodeService.getStillingskodeResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> stillingskodeService.getStillingskodeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public UketimetallResource getTimerPerUke(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
         return arbeidsforhold.getTimerPerUke()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> uketimetallService.getUketimetallResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> uketimetallService.getUketimetallResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public OrganisasjonselementResource getArbeidssted(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
         return arbeidsforhold.getArbeidssted()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public PersonalressursResource getPersonalleder(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
         return arbeidsforhold.getPersonalleder()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public PersonalressursResource getPersonalressurs(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
         return arbeidsforhold.getPersonalressurs()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public UndervisningsforholdResource getUndervisningsforhold(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
         return arbeidsforhold.getUndervisningsforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdResolver.java
@@ -4,10 +4,6 @@ package no.fint.graphql.model.administrasjon.arbeidsforhold;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.ansvar.AnsvarService;
 import no.fint.graphql.model.administrasjon.arbeidsforholdstype.ArbeidsforholdstypeService;
@@ -19,9 +15,8 @@ import no.fint.graphql.model.administrasjon.personalressurs.PersonalressursServi
 import no.fint.graphql.model.utdanning.undervisningsforhold.UndervisningsforholdService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.personal.ArbeidsforholdResource;
-
-
 import no.fint.model.resource.administrasjon.kodeverk.AnsvarResource;
 import no.fint.model.resource.administrasjon.kodeverk.ArbeidsforholdstypeResource;
 import no.fint.model.resource.administrasjon.kodeverk.FunksjonResource;
@@ -31,13 +26,14 @@ import no.fint.model.resource.administrasjon.organisasjon.OrganisasjonselementRe
 import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
 import no.fint.model.resource.utdanning.elev.UndervisningsforholdResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("administrasjonArbeidsforholdResolver")
 public class ArbeidsforholdResolver implements GraphQLResolver<ArbeidsforholdResource> {
-
 
     @Autowired
     private AnsvarService ansvarService;
@@ -65,57 +61,75 @@ public class ArbeidsforholdResolver implements GraphQLResolver<ArbeidsforholdRes
 
 
     public AnsvarResource getAnsvar(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return ansvarService.getAnsvarResource(
-            Links.get(arbeidsforhold.getAnsvar()),
-            dfe);
+        return arbeidsforhold.getAnsvar()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> ansvarService.getAnsvarResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public ArbeidsforholdstypeResource getArbeidsforholdstype(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return arbeidsforholdstypeService.getArbeidsforholdstypeResource(
-            Links.get(arbeidsforhold.getArbeidsforholdstype()),
-            dfe);
+        return arbeidsforhold.getArbeidsforholdstype()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> arbeidsforholdstypeService.getArbeidsforholdstypeResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public FunksjonResource getFunksjon(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return funksjonService.getFunksjonResource(
-            Links.get(arbeidsforhold.getFunksjon()),
-            dfe);
+        return arbeidsforhold.getFunksjon()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> funksjonService.getFunksjonResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public StillingskodeResource getStillingskode(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return stillingskodeService.getStillingskodeResource(
-            Links.get(arbeidsforhold.getStillingskode()),
-            dfe);
+        return arbeidsforhold.getStillingskode()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> stillingskodeService.getStillingskodeResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public UketimetallResource getTimerPerUke(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return uketimetallService.getUketimetallResource(
-            Links.get(arbeidsforhold.getTimerPerUke()),
-            dfe);
+        return arbeidsforhold.getTimerPerUke()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> uketimetallService.getUketimetallResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public OrganisasjonselementResource getArbeidssted(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return organisasjonselementService.getOrganisasjonselementResource(
-            Links.get(arbeidsforhold.getArbeidssted()),
-            dfe);
+        return arbeidsforhold.getArbeidssted()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public PersonalressursResource getPersonalleder(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(arbeidsforhold.getPersonalleder()),
-            dfe);
+        return arbeidsforhold.getPersonalleder()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public PersonalressursResource getPersonalressurs(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(arbeidsforhold.getPersonalressurs()),
-            dfe);
+        return arbeidsforhold.getPersonalressurs()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public UndervisningsforholdResource getUndervisningsforhold(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return undervisningsforholdService.getUndervisningsforholdResource(
-            Links.get(arbeidsforhold.getUndervisningsforhold()),
-            dfe);
+        return arbeidsforhold.getUndervisningsforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.arbeidsforhold;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.personal.ArbeidsforholdResource;
-import no.fint.model.resource.administrasjon.personal.ArbeidsforholdResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class ArbeidsforholdService {
     @Autowired
     private Endpoints endpoints;
 
-    public ArbeidsforholdResources getArbeidsforholdResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonPersonal() + "/arbeidsforhold",
-                    sinceTimeStamp),
-                ArbeidsforholdResources.class,
-                dfe);
+    public ArbeidsforholdResource getArbeidsforholdResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getArbeidsforholdResource(
+            endpoints.getAdministrasjonPersonal() 
+                + "/arbeidsforhold/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public ArbeidsforholdResource getArbeidsforholdResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforholdstype/ArbeidsforholdstypeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforholdstype/ArbeidsforholdstypeQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.arbeidsforholdstype;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.kodeverk.ArbeidsforholdstypeResource;
-import no.fint.model.resource.administrasjon.kodeverk.ArbeidsforholdstypeResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonArbeidsforholdstypeQueryResolver")
 public class ArbeidsforholdstypeQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class ArbeidsforholdstypeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ArbeidsforholdstypeService service;
 
-    public List<ArbeidsforholdstypeResource> getArbeidsforholdstype(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        ArbeidsforholdstypeResources resources = service.getArbeidsforholdstypeResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public ArbeidsforholdstypeResource getArbeidsforholdstype(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getArbeidsforholdstypeResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforholdstype/ArbeidsforholdstypeResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforholdstype/ArbeidsforholdstypeResolver.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("administrasjonArbeidsforholdstypeResolver")
@@ -27,10 +28,11 @@ public class ArbeidsforholdstypeResolver implements GraphQLResolver<Arbeidsforho
 
     public ArbeidsforholdstypeResource getForelder(ArbeidsforholdstypeResource arbeidsforholdstype, DataFetchingEnvironment dfe) {
         return arbeidsforholdstype.getForelder()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> arbeidsforholdstypeService.getArbeidsforholdstypeResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> arbeidsforholdstypeService.getArbeidsforholdstypeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforholdstype/ArbeidsforholdstypeResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforholdstype/ArbeidsforholdstypeResolver.java
@@ -4,35 +4,33 @@ package no.fint.graphql.model.administrasjon.arbeidsforholdstype;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.arbeidsforholdstype.ArbeidsforholdstypeService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.kodeverk.ArbeidsforholdstypeResource;
-
-
 import no.fint.model.resource.administrasjon.kodeverk.ArbeidsforholdstypeResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("administrasjonArbeidsforholdstypeResolver")
 public class ArbeidsforholdstypeResolver implements GraphQLResolver<ArbeidsforholdstypeResource> {
-
 
     @Autowired
     private ArbeidsforholdstypeService arbeidsforholdstypeService;
 
 
     public ArbeidsforholdstypeResource getForelder(ArbeidsforholdstypeResource arbeidsforholdstype, DataFetchingEnvironment dfe) {
-        return arbeidsforholdstypeService.getArbeidsforholdstypeResource(
-            Links.get(arbeidsforholdstype.getForelder()),
-            dfe);
+        return arbeidsforholdstype.getForelder()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> arbeidsforholdstypeService.getArbeidsforholdstypeResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforholdstype/ArbeidsforholdstypeService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforholdstype/ArbeidsforholdstypeService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.arbeidsforholdstype;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.ArbeidsforholdstypeResource;
-import no.fint.model.resource.administrasjon.kodeverk.ArbeidsforholdstypeResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class ArbeidsforholdstypeService {
     @Autowired
     private Endpoints endpoints;
 
-    public ArbeidsforholdstypeResources getArbeidsforholdstypeResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonKodeverk() + "/arbeidsforholdstype",
-                    sinceTimeStamp),
-                ArbeidsforholdstypeResources.class,
-                dfe);
+    public ArbeidsforholdstypeResource getArbeidsforholdstypeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getArbeidsforholdstypeResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/arbeidsforholdstype/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public ArbeidsforholdstypeResource getArbeidsforholdstypeResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/art/ArtQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/art/ArtQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.art;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.kodeverk.ArtResource;
-import no.fint.model.resource.administrasjon.kodeverk.ArtResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonArtQueryResolver")
 public class ArtQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class ArtQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ArtService service;
 
-    public List<ArtResource> getArt(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        ArtResources resources = service.getArtResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public ArtResource getArt(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getArtResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/art/ArtResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/art/ArtResolver.java
@@ -4,35 +4,33 @@ package no.fint.graphql.model.administrasjon.art;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.fullmakt.FullmaktService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.kodeverk.ArtResource;
-
-
 import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("administrasjonArtResolver")
 public class ArtResolver implements GraphQLResolver<ArtResource> {
-
 
     @Autowired
     private FullmaktService fullmaktService;
 
 
-    public FullmaktResource getFullmakt(ArtResource art, DataFetchingEnvironment dfe) {
-        return fullmaktService.getFullmaktResource(
-            Links.get(art.getFullmakt()),
-            dfe);
+    public List<FullmaktResource> getFullmakt(ArtResource art, DataFetchingEnvironment dfe) {
+        return art.getFullmakt()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> fullmaktService.getFullmaktResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/art/ArtResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/art/ArtResolver.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("administrasjonArtResolver")
@@ -27,10 +28,11 @@ public class ArtResolver implements GraphQLResolver<ArtResource> {
 
     public List<FullmaktResource> getFullmakt(ArtResource art, DataFetchingEnvironment dfe) {
         return art.getFullmakt()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> fullmaktService.getFullmaktResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/art/ArtService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/art/ArtService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.art;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.ArtResource;
-import no.fint.model.resource.administrasjon.kodeverk.ArtResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class ArtService {
     @Autowired
     private Endpoints endpoints;
 
-    public ArtResources getArtResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonKodeverk() + "/art",
-                    sinceTimeStamp),
-                ArtResources.class,
-                dfe);
+    public ArtResource getArtResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getArtResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/art/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public ArtResource getArtResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.fastlonn;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.personal.FastlonnResource;
-import no.fint.model.resource.administrasjon.personal.FastlonnResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonFastlonnQueryResolver")
 public class FastlonnQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class FastlonnQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private FastlonnService service;
 
-    public List<FastlonnResource> getFastlonn(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        FastlonnResources resources = service.getFastlonnResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public FastlonnResource getFastlonn(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getFastlonnResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnResolver.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("administrasjonFastlonnResolver")
@@ -37,42 +38,47 @@ public class FastlonnResolver implements GraphQLResolver<FastlonnResource> {
 
     public LonnsartResource getLonnsart(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
         return fastlonn.getLonnsart()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> lonnsartService.getLonnsartResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> lonnsartService.getLonnsartResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public PersonalressursResource getAnviser(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
         return fastlonn.getAnviser()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public PersonalressursResource getKonterer(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
         return fastlonn.getKonterer()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public PersonalressursResource getAttestant(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
         return fastlonn.getAttestant()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public ArbeidsforholdResource getArbeidsforhold(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
         return fastlonn.getArbeidsforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnResolver.java
@@ -4,30 +4,26 @@ package no.fint.graphql.model.administrasjon.fastlonn;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.lonnsart.LonnsartService;
 import no.fint.graphql.model.administrasjon.personalressurs.PersonalressursService;
 import no.fint.graphql.model.administrasjon.arbeidsforhold.ArbeidsforholdService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.personal.FastlonnResource;
-
-
 import no.fint.model.resource.administrasjon.kodeverk.LonnsartResource;
 import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
 import no.fint.model.resource.administrasjon.personal.ArbeidsforholdResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("administrasjonFastlonnResolver")
 public class FastlonnResolver implements GraphQLResolver<FastlonnResource> {
-
 
     @Autowired
     private LonnsartService lonnsartService;
@@ -40,33 +36,43 @@ public class FastlonnResolver implements GraphQLResolver<FastlonnResource> {
 
 
     public LonnsartResource getLonnsart(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
-        return lonnsartService.getLonnsartResource(
-            Links.get(fastlonn.getLonnsart()),
-            dfe);
+        return fastlonn.getLonnsart()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> lonnsartService.getLonnsartResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public PersonalressursResource getAnviser(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(fastlonn.getAnviser()),
-            dfe);
+        return fastlonn.getAnviser()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public PersonalressursResource getKonterer(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(fastlonn.getKonterer()),
-            dfe);
+        return fastlonn.getKonterer()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public PersonalressursResource getAttestant(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(fastlonn.getAttestant()),
-            dfe);
+        return fastlonn.getAttestant()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public ArbeidsforholdResource getArbeidsforhold(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
-        return arbeidsforholdService.getArbeidsforholdResource(
-            Links.get(fastlonn.getArbeidsforhold()),
-            dfe);
+        return fastlonn.getArbeidsforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.fastlonn;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.personal.FastlonnResource;
-import no.fint.model.resource.administrasjon.personal.FastlonnResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class FastlonnService {
     @Autowired
     private Endpoints endpoints;
 
-    public FastlonnResources getFastlonnResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonPersonal() + "/fastlonn",
-                    sinceTimeStamp),
-                FastlonnResources.class,
-                dfe);
+    public FastlonnResource getFastlonnResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getFastlonnResource(
+            endpoints.getAdministrasjonPersonal() 
+                + "/fastlonn/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public FastlonnResource getFastlonnResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.fasttillegg;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.personal.FasttilleggResource;
-import no.fint.model.resource.administrasjon.personal.FasttilleggResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonFasttilleggQueryResolver")
 public class FasttilleggQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class FasttilleggQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private FasttilleggService service;
 
-    public List<FasttilleggResource> getFasttillegg(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        FasttilleggResources resources = service.getFasttilleggResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public FasttilleggResource getFasttillegg(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getFasttilleggResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggResolver.java
@@ -4,30 +4,26 @@ package no.fint.graphql.model.administrasjon.fasttillegg;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.lonnsart.LonnsartService;
 import no.fint.graphql.model.administrasjon.personalressurs.PersonalressursService;
 import no.fint.graphql.model.administrasjon.arbeidsforhold.ArbeidsforholdService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.personal.FasttilleggResource;
-
-
 import no.fint.model.resource.administrasjon.kodeverk.LonnsartResource;
 import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
 import no.fint.model.resource.administrasjon.personal.ArbeidsforholdResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("administrasjonFasttilleggResolver")
 public class FasttilleggResolver implements GraphQLResolver<FasttilleggResource> {
-
 
     @Autowired
     private LonnsartService lonnsartService;
@@ -40,33 +36,43 @@ public class FasttilleggResolver implements GraphQLResolver<FasttilleggResource>
 
 
     public LonnsartResource getLonnsart(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
-        return lonnsartService.getLonnsartResource(
-            Links.get(fasttillegg.getLonnsart()),
-            dfe);
+        return fasttillegg.getLonnsart()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> lonnsartService.getLonnsartResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public PersonalressursResource getAnviser(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(fasttillegg.getAnviser()),
-            dfe);
+        return fasttillegg.getAnviser()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public PersonalressursResource getKonterer(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(fasttillegg.getKonterer()),
-            dfe);
+        return fasttillegg.getKonterer()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public PersonalressursResource getAttestant(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(fasttillegg.getAttestant()),
-            dfe);
+        return fasttillegg.getAttestant()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public ArbeidsforholdResource getArbeidsforhold(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
-        return arbeidsforholdService.getArbeidsforholdResource(
-            Links.get(fasttillegg.getArbeidsforhold()),
-            dfe);
+        return fasttillegg.getArbeidsforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggResolver.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("administrasjonFasttilleggResolver")
@@ -37,42 +38,47 @@ public class FasttilleggResolver implements GraphQLResolver<FasttilleggResource>
 
     public LonnsartResource getLonnsart(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
         return fasttillegg.getLonnsart()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> lonnsartService.getLonnsartResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> lonnsartService.getLonnsartResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public PersonalressursResource getAnviser(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
         return fasttillegg.getAnviser()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public PersonalressursResource getKonterer(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
         return fasttillegg.getKonterer()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public PersonalressursResource getAttestant(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
         return fasttillegg.getAttestant()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public ArbeidsforholdResource getArbeidsforhold(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
         return fasttillegg.getArbeidsforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.fasttillegg;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.personal.FasttilleggResource;
-import no.fint.model.resource.administrasjon.personal.FasttilleggResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class FasttilleggService {
     @Autowired
     private Endpoints endpoints;
 
-    public FasttilleggResources getFasttilleggResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonPersonal() + "/fasttillegg",
-                    sinceTimeStamp),
-                FasttilleggResources.class,
-                dfe);
+    public FasttilleggResource getFasttilleggResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getFasttilleggResource(
+            endpoints.getAdministrasjonPersonal() 
+                + "/fasttillegg/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public FasttilleggResource getFasttilleggResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.fullmakt;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
-import no.fint.model.resource.administrasjon.fullmakt.FullmaktResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonFullmaktQueryResolver")
 public class FullmaktQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class FullmaktQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private FullmaktService service;
 
-    public List<FullmaktResource> getFullmakt(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        FullmaktResources resources = service.getFullmaktResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public FullmaktResource getFullmakt(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getFullmaktResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktResolver.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("administrasjonFullmaktResolver")
@@ -32,26 +33,29 @@ public class FullmaktResolver implements GraphQLResolver<FullmaktResource> {
 
     public PersonalressursResource getStedfortreder(FullmaktResource fullmakt, DataFetchingEnvironment dfe) {
         return fullmakt.getStedfortreder()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public PersonalressursResource getFullmektig(FullmaktResource fullmakt, DataFetchingEnvironment dfe) {
         return fullmakt.getFullmektig()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public RolleResource getRolle(FullmaktResource fullmakt, DataFetchingEnvironment dfe) {
         return fullmakt.getRolle()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> rolleService.getRolleResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> rolleService.getRolleResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktResolver.java
@@ -4,28 +4,24 @@ package no.fint.graphql.model.administrasjon.fullmakt;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.personalressurs.PersonalressursService;
 import no.fint.graphql.model.administrasjon.rolle.RolleService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
-
-
 import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
 import no.fint.model.resource.administrasjon.fullmakt.RolleResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("administrasjonFullmaktResolver")
 public class FullmaktResolver implements GraphQLResolver<FullmaktResource> {
-
 
     @Autowired
     private PersonalressursService personalressursService;
@@ -35,21 +31,27 @@ public class FullmaktResolver implements GraphQLResolver<FullmaktResource> {
 
 
     public PersonalressursResource getStedfortreder(FullmaktResource fullmakt, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(fullmakt.getStedfortreder()),
-            dfe);
+        return fullmakt.getStedfortreder()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public PersonalressursResource getFullmektig(FullmaktResource fullmakt, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(fullmakt.getFullmektig()),
-            dfe);
+        return fullmakt.getFullmektig()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public RolleResource getRolle(FullmaktResource fullmakt, DataFetchingEnvironment dfe) {
-        return rolleService.getRolleResource(
-            Links.get(fullmakt.getRolle()),
-            dfe);
+        return fullmakt.getRolle()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> rolleService.getRolleResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.fullmakt;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
-import no.fint.model.resource.administrasjon.fullmakt.FullmaktResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class FullmaktService {
     @Autowired
     private Endpoints endpoints;
 
-    public FullmaktResources getFullmaktResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonFullmakt() + "/fullmakt",
-                    sinceTimeStamp),
-                FullmaktResources.class,
-                dfe);
+    public FullmaktResource getFullmaktResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getFullmaktResource(
+            endpoints.getAdministrasjonFullmakt() 
+                + "/fullmakt/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public FullmaktResource getFullmaktResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.funksjon;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.kodeverk.FunksjonResource;
-import no.fint.model.resource.administrasjon.kodeverk.FunksjonResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonFunksjonQueryResolver")
 public class FunksjonQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class FunksjonQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private FunksjonService service;
 
-    public List<FunksjonResource> getFunksjon(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        FunksjonResources resources = service.getFunksjonResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public FunksjonResource getFunksjon(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getFunksjonResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonResolver.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("administrasjonFunksjonResolver")
@@ -32,26 +33,29 @@ public class FunksjonResolver implements GraphQLResolver<FunksjonResource> {
 
     public FunksjonResource getOverordnet(FunksjonResource funksjon, DataFetchingEnvironment dfe) {
         return funksjon.getOverordnet()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> funksjonService.getFunksjonResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> funksjonService.getFunksjonResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<FunksjonResource> getUnderordnet(FunksjonResource funksjon, DataFetchingEnvironment dfe) {
         return funksjon.getUnderordnet()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> funksjonService.getFunksjonResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> funksjonService.getFunksjonResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<FullmaktResource> getFullmakt(FunksjonResource funksjon, DataFetchingEnvironment dfe) {
         return funksjon.getFullmakt()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> fullmaktService.getFullmaktResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonResolver.java
@@ -4,28 +4,24 @@ package no.fint.graphql.model.administrasjon.funksjon;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.funksjon.FunksjonService;
 import no.fint.graphql.model.administrasjon.fullmakt.FullmaktService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.kodeverk.FunksjonResource;
-
-
 import no.fint.model.resource.administrasjon.kodeverk.FunksjonResource;
 import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("administrasjonFunksjonResolver")
 public class FunksjonResolver implements GraphQLResolver<FunksjonResource> {
-
 
     @Autowired
     private FunksjonService funksjonService;
@@ -35,21 +31,27 @@ public class FunksjonResolver implements GraphQLResolver<FunksjonResource> {
 
 
     public FunksjonResource getOverordnet(FunksjonResource funksjon, DataFetchingEnvironment dfe) {
-        return funksjonService.getFunksjonResource(
-            Links.get(funksjon.getOverordnet()),
-            dfe);
+        return funksjon.getOverordnet()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> funksjonService.getFunksjonResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public FunksjonResource getUnderordnet(FunksjonResource funksjon, DataFetchingEnvironment dfe) {
-        return funksjonService.getFunksjonResource(
-            Links.get(funksjon.getUnderordnet()),
-            dfe);
+    public List<FunksjonResource> getUnderordnet(FunksjonResource funksjon, DataFetchingEnvironment dfe) {
+        return funksjon.getUnderordnet()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> funksjonService.getFunksjonResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public FullmaktResource getFullmakt(FunksjonResource funksjon, DataFetchingEnvironment dfe) {
-        return fullmaktService.getFullmaktResource(
-            Links.get(funksjon.getFullmakt()),
-            dfe);
+    public List<FullmaktResource> getFullmakt(FunksjonResource funksjon, DataFetchingEnvironment dfe) {
+        return funksjon.getFullmakt()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> fullmaktService.getFullmaktResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.funksjon;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.FunksjonResource;
-import no.fint.model.resource.administrasjon.kodeverk.FunksjonResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class FunksjonService {
     @Autowired
     private Endpoints endpoints;
 
-    public FunksjonResources getFunksjonResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonKodeverk() + "/funksjon",
-                    sinceTimeStamp),
-                FunksjonResources.class,
-                dfe);
+    public FunksjonResource getFunksjonResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getFunksjonResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/funksjon/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public FunksjonResource getFunksjonResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/kontostreng/KontostrengResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/kontostreng/KontostrengResolver.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("administrasjonKontostrengResolver")
@@ -42,34 +43,38 @@ public class KontostrengResolver implements GraphQLResolver<KontostrengResource>
 
     public AnsvarResource getAnsvar(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
         return kontostreng.getAnsvar()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> ansvarService.getAnsvarResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> ansvarService.getAnsvarResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public ArtResource getArt(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
         return kontostreng.getArt()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> artService.getArtResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> artService.getArtResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public FunksjonResource getFunksjon(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
         return kontostreng.getFunksjon()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> funksjonService.getFunksjonResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> funksjonService.getFunksjonResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public ProsjektResource getProsjekt(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
         return kontostreng.getProsjekt()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> prosjektService.getProsjektResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> prosjektService.getProsjektResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/kontostreng/KontostrengResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/kontostreng/KontostrengResolver.java
@@ -4,10 +4,6 @@ package no.fint.graphql.model.administrasjon.kontostreng;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.ansvar.AnsvarService;
 import no.fint.graphql.model.administrasjon.art.ArtService;
@@ -15,21 +11,21 @@ import no.fint.graphql.model.administrasjon.funksjon.FunksjonService;
 import no.fint.graphql.model.administrasjon.prosjekt.ProsjektService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.kompleksedatatyper.KontostrengResource;
-
-
 import no.fint.model.resource.administrasjon.kodeverk.AnsvarResource;
 import no.fint.model.resource.administrasjon.kodeverk.ArtResource;
 import no.fint.model.resource.administrasjon.kodeverk.FunksjonResource;
 import no.fint.model.resource.administrasjon.kodeverk.ProsjektResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("administrasjonKontostrengResolver")
 public class KontostrengResolver implements GraphQLResolver<KontostrengResource> {
-
 
     @Autowired
     private AnsvarService ansvarService;
@@ -45,27 +41,35 @@ public class KontostrengResolver implements GraphQLResolver<KontostrengResource>
 
 
     public AnsvarResource getAnsvar(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
-        return ansvarService.getAnsvarResource(
-            Links.get(kontostreng.getAnsvar()),
-            dfe);
+        return kontostreng.getAnsvar()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> ansvarService.getAnsvarResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public ArtResource getArt(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
-        return artService.getArtResource(
-            Links.get(kontostreng.getArt()),
-            dfe);
+        return kontostreng.getArt()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> artService.getArtResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public FunksjonResource getFunksjon(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
-        return funksjonService.getFunksjonResource(
-            Links.get(kontostreng.getFunksjon()),
-            dfe);
+        return kontostreng.getFunksjon()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> funksjonService.getFunksjonResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public ProsjektResource getProsjekt(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
-        return prosjektService.getProsjektResource(
-            Links.get(kontostreng.getProsjekt()),
-            dfe);
+        return kontostreng.getProsjekt()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> prosjektService.getProsjektResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/lonnsart/LonnsartQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/lonnsart/LonnsartQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.lonnsart;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.kodeverk.LonnsartResource;
-import no.fint.model.resource.administrasjon.kodeverk.LonnsartResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonLonnsartQueryResolver")
 public class LonnsartQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class LonnsartQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private LonnsartService service;
 
-    public List<LonnsartResource> getLonnsart(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        LonnsartResources resources = service.getLonnsartResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public LonnsartResource getLonnsart(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getLonnsartResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/lonnsart/LonnsartService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/lonnsart/LonnsartService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.lonnsart;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.LonnsartResource;
-import no.fint.model.resource.administrasjon.kodeverk.LonnsartResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class LonnsartService {
     @Autowired
     private Endpoints endpoints;
 
-    public LonnsartResources getLonnsartResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonKodeverk() + "/lonnsart",
-                    sinceTimeStamp),
-                LonnsartResources.class,
-                dfe);
+    public LonnsartResource getLonnsartResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getLonnsartResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/lonnsart/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public LonnsartResource getLonnsartResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.organisasjonselement;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.organisasjon.OrganisasjonselementResource;
-import no.fint.model.resource.administrasjon.organisasjon.OrganisasjonselementResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonOrganisasjonselementQueryResolver")
 public class OrganisasjonselementQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,20 @@ public class OrganisasjonselementQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private OrganisasjonselementService service;
 
-    public List<OrganisasjonselementResource> getOrganisasjonselement(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        OrganisasjonselementResources resources = service.getOrganisasjonselementResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public OrganisasjonselementResource getOrganisasjonselement(
+            String organisasjonsId,
+            String organisasjonsKode,
+            String organisasjonsnummer,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(organisasjonsId)) {
+            return service.getOrganisasjonselementResourceById("organisasjonsid", organisasjonsId, dfe);
+        }
+        if (StringUtils.isNotEmpty(organisasjonsKode)) {
+            return service.getOrganisasjonselementResourceById("organisasjonskode", organisasjonsKode, dfe);
+        }
+        if (StringUtils.isNotEmpty(organisasjonsnummer)) {
+            return service.getOrganisasjonselementResourceById("organisasjonsnummer", organisasjonsnummer, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementResolver.java
@@ -4,10 +4,6 @@ package no.fint.graphql.model.administrasjon.organisasjonselement;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.ansvar.AnsvarService;
 import no.fint.graphql.model.administrasjon.personalressurs.PersonalressursService;
@@ -16,22 +12,22 @@ import no.fint.graphql.model.utdanning.skole.SkoleService;
 import no.fint.graphql.model.administrasjon.arbeidsforhold.ArbeidsforholdService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.organisasjon.OrganisasjonselementResource;
-
-
 import no.fint.model.resource.administrasjon.kodeverk.AnsvarResource;
 import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
 import no.fint.model.resource.administrasjon.organisasjon.OrganisasjonselementResource;
 import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
 import no.fint.model.resource.administrasjon.personal.ArbeidsforholdResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("administrasjonOrganisasjonselementResolver")
 public class OrganisasjonselementResolver implements GraphQLResolver<OrganisasjonselementResource> {
-
 
     @Autowired
     private AnsvarService ansvarService;
@@ -49,40 +45,52 @@ public class OrganisasjonselementResolver implements GraphQLResolver<Organisasjo
     private ArbeidsforholdService arbeidsforholdService;
 
 
-    public AnsvarResource getAnsvar(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
-        return ansvarService.getAnsvarResource(
-            Links.get(organisasjonselement.getAnsvar()),
-            dfe);
+    public List<AnsvarResource> getAnsvar(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
+        return organisasjonselement.getAnsvar()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> ansvarService.getAnsvarResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
     public PersonalressursResource getLeder(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(organisasjonselement.getLeder()),
-            dfe);
+        return organisasjonselement.getLeder()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public OrganisasjonselementResource getOverordnet(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
-        return organisasjonselementService.getOrganisasjonselementResource(
-            Links.get(organisasjonselement.getOverordnet()),
-            dfe);
+        return organisasjonselement.getOverordnet()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public OrganisasjonselementResource getUnderordnet(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
-        return organisasjonselementService.getOrganisasjonselementResource(
-            Links.get(organisasjonselement.getUnderordnet()),
-            dfe);
+    public List<OrganisasjonselementResource> getUnderordnet(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
+        return organisasjonselement.getUnderordnet()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
     public SkoleResource getSkole(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
-        return skoleService.getSkoleResource(
-            Links.get(organisasjonselement.getSkole()),
-            dfe);
+        return organisasjonselement.getSkole()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> skoleService.getSkoleResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public ArbeidsforholdResource getArbeidsforhold(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
-        return arbeidsforholdService.getArbeidsforholdResource(
-            Links.get(organisasjonselement.getArbeidsforhold()),
-            dfe);
+    public List<ArbeidsforholdResource> getArbeidsforhold(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
+        return organisasjonselement.getArbeidsforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementResolver.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("administrasjonOrganisasjonselementResolver")
@@ -47,50 +48,56 @@ public class OrganisasjonselementResolver implements GraphQLResolver<Organisasjo
 
     public List<AnsvarResource> getAnsvar(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
         return organisasjonselement.getAnsvar()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> ansvarService.getAnsvarResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> ansvarService.getAnsvarResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public PersonalressursResource getLeder(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
         return organisasjonselement.getLeder()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public OrganisasjonselementResource getOverordnet(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
         return organisasjonselement.getOverordnet()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<OrganisasjonselementResource> getUnderordnet(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
         return organisasjonselement.getUnderordnet()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public SkoleResource getSkole(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
         return organisasjonselement.getSkole()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> skoleService.getSkoleResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> skoleService.getSkoleResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<ArbeidsforholdResource> getArbeidsforhold(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
         return organisasjonselement.getArbeidsforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.organisasjonselement;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.organisasjon.OrganisasjonselementResource;
-import no.fint.model.resource.administrasjon.organisasjon.OrganisasjonselementResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class OrganisasjonselementService {
     @Autowired
     private Endpoints endpoints;
 
-    public OrganisasjonselementResources getOrganisasjonselementResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonOrganisasjon() + "/organisasjonselement",
-                    sinceTimeStamp),
-                OrganisasjonselementResources.class,
-                dfe);
+    public OrganisasjonselementResource getOrganisasjonselementResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getOrganisasjonselementResource(
+            endpoints.getAdministrasjonOrganisasjon() 
+                + "/organisasjonselement/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public OrganisasjonselementResource getOrganisasjonselementResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.personalressurs;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
-import no.fint.model.resource.administrasjon.personal.PersonalressursResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonPersonalressursQueryResolver")
 public class PersonalressursQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,20 @@ public class PersonalressursQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private PersonalressursService service;
 
-    public List<PersonalressursResource> getPersonalressurs(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        PersonalressursResources resources = service.getPersonalressursResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public PersonalressursResource getPersonalressurs(
+            String ansattnummer,
+            String brukernavn,
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(ansattnummer)) {
+            return service.getPersonalressursResourceById("ansattnummer", ansattnummer, dfe);
+        }
+        if (StringUtils.isNotEmpty(brukernavn)) {
+            return service.getPersonalressursResourceById("brukernavn", brukernavn, dfe);
+        }
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getPersonalressursResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursResolver.java
@@ -4,10 +4,6 @@ package no.fint.graphql.model.administrasjon.personalressurs;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.personalressurskategori.PersonalressurskategoriService;
 import no.fint.graphql.model.administrasjon.arbeidsforhold.ArbeidsforholdService;
@@ -17,9 +13,8 @@ import no.fint.graphql.model.administrasjon.organisasjonselement.Organisasjonsel
 import no.fint.graphql.model.utdanning.skoleressurs.SkoleressursService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
-
-
 import no.fint.model.resource.administrasjon.kodeverk.PersonalressurskategoriResource;
 import no.fint.model.resource.administrasjon.personal.ArbeidsforholdResource;
 import no.fint.model.resource.felles.PersonResource;
@@ -27,13 +22,14 @@ import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
 import no.fint.model.resource.administrasjon.organisasjon.OrganisasjonselementResource;
 import no.fint.model.resource.utdanning.elev.SkoleressursResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("administrasjonPersonalressursResolver")
 public class PersonalressursResolver implements GraphQLResolver<PersonalressursResource> {
-
 
     @Autowired
     private PersonalressurskategoriService personalressurskategoriService;
@@ -55,51 +51,67 @@ public class PersonalressursResolver implements GraphQLResolver<PersonalressursR
 
 
     public PersonalressurskategoriResource getPersonalressurskategori(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
-        return personalressurskategoriService.getPersonalressurskategoriResource(
-            Links.get(personalressurs.getPersonalressurskategori()),
-            dfe);
+        return personalressurs.getPersonalressurskategori()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressurskategoriService.getPersonalressurskategoriResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public ArbeidsforholdResource getArbeidsforhold(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
-        return arbeidsforholdService.getArbeidsforholdResource(
-            Links.get(personalressurs.getArbeidsforhold()),
-            dfe);
+    public List<ArbeidsforholdResource> getArbeidsforhold(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
+        return personalressurs.getArbeidsforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
     public PersonResource getPerson(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
-        return personService.getPersonResource(
-            Links.get(personalressurs.getPerson()),
-            dfe);
+        return personalressurs.getPerson()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personService.getPersonResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public FullmaktResource getStedfortreder(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
-        return fullmaktService.getFullmaktResource(
-            Links.get(personalressurs.getStedfortreder()),
-            dfe);
+    public List<FullmaktResource> getStedfortreder(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
+        return personalressurs.getStedfortreder()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> fullmaktService.getFullmaktResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public FullmaktResource getFullmakt(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
-        return fullmaktService.getFullmaktResource(
-            Links.get(personalressurs.getFullmakt()),
-            dfe);
+    public List<FullmaktResource> getFullmakt(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
+        return personalressurs.getFullmakt()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> fullmaktService.getFullmaktResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public OrganisasjonselementResource getLeder(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
-        return organisasjonselementService.getOrganisasjonselementResource(
-            Links.get(personalressurs.getLeder()),
-            dfe);
+    public List<OrganisasjonselementResource> getLeder(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
+        return personalressurs.getLeder()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public ArbeidsforholdResource getPersonalansvar(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
-        return arbeidsforholdService.getArbeidsforholdResource(
-            Links.get(personalressurs.getPersonalansvar()),
-            dfe);
+    public List<ArbeidsforholdResource> getPersonalansvar(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
+        return personalressurs.getPersonalansvar()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
     public SkoleressursResource getSkoleressurs(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
-        return skoleressursService.getSkoleressursResource(
-            Links.get(personalressurs.getSkoleressurs()),
-            dfe);
+        return personalressurs.getSkoleressurs()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> skoleressursService.getSkoleressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursResolver.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("administrasjonPersonalressursResolver")
@@ -52,66 +53,74 @@ public class PersonalressursResolver implements GraphQLResolver<PersonalressursR
 
     public PersonalressurskategoriResource getPersonalressurskategori(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
         return personalressurs.getPersonalressurskategori()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressurskategoriService.getPersonalressurskategoriResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressurskategoriService.getPersonalressurskategoriResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<ArbeidsforholdResource> getArbeidsforhold(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
         return personalressurs.getArbeidsforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public PersonResource getPerson(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
         return personalressurs.getPerson()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personService.getPersonResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personService.getPersonResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<FullmaktResource> getStedfortreder(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
         return personalressurs.getStedfortreder()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> fullmaktService.getFullmaktResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<FullmaktResource> getFullmakt(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
         return personalressurs.getFullmakt()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> fullmaktService.getFullmaktResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<OrganisasjonselementResource> getLeder(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
         return personalressurs.getLeder()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<ArbeidsforholdResource> getPersonalansvar(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
         return personalressurs.getPersonalansvar()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public SkoleressursResource getSkoleressurs(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
         return personalressurs.getSkoleressurs()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> skoleressursService.getSkoleressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> skoleressursService.getSkoleressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.personalressurs;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
-import no.fint.model.resource.administrasjon.personal.PersonalressursResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class PersonalressursService {
     @Autowired
     private Endpoints endpoints;
 
-    public PersonalressursResources getPersonalressursResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonPersonal() + "/personalressurs",
-                    sinceTimeStamp),
-                PersonalressursResources.class,
-                dfe);
+    public PersonalressursResource getPersonalressursResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getPersonalressursResource(
+            endpoints.getAdministrasjonPersonal() 
+                + "/personalressurs/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public PersonalressursResource getPersonalressursResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/personalressurskategori/PersonalressurskategoriQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/personalressurskategori/PersonalressurskategoriQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.personalressurskategori;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.kodeverk.PersonalressurskategoriResource;
-import no.fint.model.resource.administrasjon.kodeverk.PersonalressurskategoriResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonPersonalressurskategoriQueryResolver")
 public class PersonalressurskategoriQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class PersonalressurskategoriQueryResolver implements GraphQLQueryResolve
     @Autowired
     private PersonalressurskategoriService service;
 
-    public List<PersonalressurskategoriResource> getPersonalressurskategori(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        PersonalressurskategoriResources resources = service.getPersonalressurskategoriResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public PersonalressurskategoriResource getPersonalressurskategori(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getPersonalressurskategoriResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/personalressurskategori/PersonalressurskategoriService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/personalressurskategori/PersonalressurskategoriService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.personalressurskategori;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.PersonalressurskategoriResource;
-import no.fint.model.resource.administrasjon.kodeverk.PersonalressurskategoriResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class PersonalressurskategoriService {
     @Autowired
     private Endpoints endpoints;
 
-    public PersonalressurskategoriResources getPersonalressurskategoriResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonKodeverk() + "/personalressurskategori",
-                    sinceTimeStamp),
-                PersonalressurskategoriResources.class,
-                dfe);
+    public PersonalressurskategoriResource getPersonalressurskategoriResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getPersonalressurskategoriResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/personalressurskategori/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public PersonalressurskategoriResource getPersonalressurskategoriResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/prosjekt/ProsjektQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/prosjekt/ProsjektQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.prosjekt;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.kodeverk.ProsjektResource;
-import no.fint.model.resource.administrasjon.kodeverk.ProsjektResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonProsjektQueryResolver")
 public class ProsjektQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class ProsjektQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ProsjektService service;
 
-    public List<ProsjektResource> getProsjekt(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        ProsjektResources resources = service.getProsjektResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public ProsjektResource getProsjekt(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getProsjektResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/prosjekt/ProsjektResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/prosjekt/ProsjektResolver.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("administrasjonProsjektResolver")
@@ -27,10 +28,11 @@ public class ProsjektResolver implements GraphQLResolver<ProsjektResource> {
 
     public List<FullmaktResource> getFullmakt(ProsjektResource prosjekt, DataFetchingEnvironment dfe) {
         return prosjekt.getFullmakt()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> fullmaktService.getFullmaktResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/prosjekt/ProsjektResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/prosjekt/ProsjektResolver.java
@@ -4,35 +4,33 @@ package no.fint.graphql.model.administrasjon.prosjekt;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.fullmakt.FullmaktService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.kodeverk.ProsjektResource;
-
-
 import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("administrasjonProsjektResolver")
 public class ProsjektResolver implements GraphQLResolver<ProsjektResource> {
-
 
     @Autowired
     private FullmaktService fullmaktService;
 
 
-    public FullmaktResource getFullmakt(ProsjektResource prosjekt, DataFetchingEnvironment dfe) {
-        return fullmaktService.getFullmaktResource(
-            Links.get(prosjekt.getFullmakt()),
-            dfe);
+    public List<FullmaktResource> getFullmakt(ProsjektResource prosjekt, DataFetchingEnvironment dfe) {
+        return prosjekt.getFullmakt()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> fullmaktService.getFullmaktResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/prosjekt/ProsjektService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/prosjekt/ProsjektService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.prosjekt;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.ProsjektResource;
-import no.fint.model.resource.administrasjon.kodeverk.ProsjektResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class ProsjektService {
     @Autowired
     private Endpoints endpoints;
 
-    public ProsjektResources getProsjektResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonKodeverk() + "/prosjekt",
-                    sinceTimeStamp),
-                ProsjektResources.class,
-                dfe);
+    public ProsjektResource getProsjektResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getProsjektResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/prosjekt/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public ProsjektResource getProsjektResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/rolle/RolleQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/rolle/RolleQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.rolle;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.fullmakt.RolleResource;
-import no.fint.model.resource.administrasjon.fullmakt.RolleResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonRolleQueryResolver")
 public class RolleQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class RolleQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private RolleService service;
 
-    public List<RolleResource> getRolle(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        RolleResources resources = service.getRolleResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public RolleResource getRolle(
+            String navn,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(navn)) {
+            return service.getRolleResourceById("navn", navn, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/rolle/RolleResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/rolle/RolleResolver.java
@@ -4,35 +4,33 @@ package no.fint.graphql.model.administrasjon.rolle;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.fullmakt.FullmaktService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.fullmakt.RolleResource;
-
-
 import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("administrasjonRolleResolver")
 public class RolleResolver implements GraphQLResolver<RolleResource> {
-
 
     @Autowired
     private FullmaktService fullmaktService;
 
 
-    public FullmaktResource getFullmakt(RolleResource rolle, DataFetchingEnvironment dfe) {
-        return fullmaktService.getFullmaktResource(
-            Links.get(rolle.getFullmakt()),
-            dfe);
+    public List<FullmaktResource> getFullmakt(RolleResource rolle, DataFetchingEnvironment dfe) {
+        return rolle.getFullmakt()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> fullmaktService.getFullmaktResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/rolle/RolleResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/rolle/RolleResolver.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("administrasjonRolleResolver")
@@ -27,10 +28,11 @@ public class RolleResolver implements GraphQLResolver<RolleResource> {
 
     public List<FullmaktResource> getFullmakt(RolleResource rolle, DataFetchingEnvironment dfe) {
         return rolle.getFullmakt()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> fullmaktService.getFullmaktResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/rolle/RolleService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/rolle/RolleService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.rolle;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.fullmakt.RolleResource;
-import no.fint.model.resource.administrasjon.fullmakt.RolleResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class RolleService {
     @Autowired
     private Endpoints endpoints;
 
-    public RolleResources getRolleResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonFullmakt() + "/rolle",
-                    sinceTimeStamp),
-                RolleResources.class,
-                dfe);
+    public RolleResource getRolleResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getRolleResource(
+            endpoints.getAdministrasjonFullmakt() 
+                + "/rolle/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public RolleResource getRolleResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.stillingskode;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.kodeverk.StillingskodeResource;
-import no.fint.model.resource.administrasjon.kodeverk.StillingskodeResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonStillingskodeQueryResolver")
 public class StillingskodeQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class StillingskodeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private StillingskodeService service;
 
-    public List<StillingskodeResource> getStillingskode(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        StillingskodeResources resources = service.getStillingskodeResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public StillingskodeResource getStillingskode(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getStillingskodeResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeResolver.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("administrasjonStillingskodeResolver")
@@ -27,10 +28,11 @@ public class StillingskodeResolver implements GraphQLResolver<StillingskodeResou
 
     public StillingskodeResource getForelder(StillingskodeResource stillingskode, DataFetchingEnvironment dfe) {
         return stillingskode.getForelder()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> stillingskodeService.getStillingskodeResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> stillingskodeService.getStillingskodeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeResolver.java
@@ -4,35 +4,33 @@ package no.fint.graphql.model.administrasjon.stillingskode;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.stillingskode.StillingskodeService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.kodeverk.StillingskodeResource;
-
-
 import no.fint.model.resource.administrasjon.kodeverk.StillingskodeResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("administrasjonStillingskodeResolver")
 public class StillingskodeResolver implements GraphQLResolver<StillingskodeResource> {
-
 
     @Autowired
     private StillingskodeService stillingskodeService;
 
 
     public StillingskodeResource getForelder(StillingskodeResource stillingskode, DataFetchingEnvironment dfe) {
-        return stillingskodeService.getStillingskodeResource(
-            Links.get(stillingskode.getForelder()),
-            dfe);
+        return stillingskode.getForelder()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> stillingskodeService.getStillingskodeResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.stillingskode;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.StillingskodeResource;
-import no.fint.model.resource.administrasjon.kodeverk.StillingskodeResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class StillingskodeService {
     @Autowired
     private Endpoints endpoints;
 
-    public StillingskodeResources getStillingskodeResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonKodeverk() + "/stillingskode",
-                    sinceTimeStamp),
-                StillingskodeResources.class,
-                dfe);
+    public StillingskodeResource getStillingskodeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getStillingskodeResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/stillingskode/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public StillingskodeResource getStillingskodeResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/uketimetall/UketimetallQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/uketimetall/UketimetallQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.uketimetall;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.kodeverk.UketimetallResource;
-import no.fint.model.resource.administrasjon.kodeverk.UketimetallResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonUketimetallQueryResolver")
 public class UketimetallQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class UketimetallQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private UketimetallService service;
 
-    public List<UketimetallResource> getUketimetall(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        UketimetallResources resources = service.getUketimetallResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public UketimetallResource getUketimetall(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getUketimetallResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/uketimetall/UketimetallService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/uketimetall/UketimetallService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.uketimetall;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.UketimetallResource;
-import no.fint.model.resource.administrasjon.kodeverk.UketimetallResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class UketimetallService {
     @Autowired
     private Endpoints endpoints;
 
-    public UketimetallResources getUketimetallResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonKodeverk() + "/uketimetall",
-                    sinceTimeStamp),
-                UketimetallResources.class,
-                dfe);
+    public UketimetallResource getUketimetallResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getUketimetallResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/uketimetall/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public UketimetallResource getUketimetallResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.administrasjon.variabellonn;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.administrasjon.personal.VariabellonnResource;
-import no.fint.model.resource.administrasjon.personal.VariabellonnResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("administrasjonVariabellonnQueryResolver")
 public class VariabellonnQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class VariabellonnQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private VariabellonnService service;
 
-    public List<VariabellonnResource> getVariabellonn(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        VariabellonnResources resources = service.getVariabellonnResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public VariabellonnResource getVariabellonn(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getVariabellonnResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnResolver.java
@@ -4,30 +4,26 @@ package no.fint.graphql.model.administrasjon.variabellonn;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.lonnsart.LonnsartService;
 import no.fint.graphql.model.administrasjon.personalressurs.PersonalressursService;
 import no.fint.graphql.model.administrasjon.arbeidsforhold.ArbeidsforholdService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.personal.VariabellonnResource;
-
-
 import no.fint.model.resource.administrasjon.kodeverk.LonnsartResource;
 import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
 import no.fint.model.resource.administrasjon.personal.ArbeidsforholdResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("administrasjonVariabellonnResolver")
 public class VariabellonnResolver implements GraphQLResolver<VariabellonnResource> {
-
 
     @Autowired
     private LonnsartService lonnsartService;
@@ -40,33 +36,43 @@ public class VariabellonnResolver implements GraphQLResolver<VariabellonnResourc
 
 
     public LonnsartResource getLonnsart(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
-        return lonnsartService.getLonnsartResource(
-            Links.get(variabellonn.getLonnsart()),
-            dfe);
+        return variabellonn.getLonnsart()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> lonnsartService.getLonnsartResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public PersonalressursResource getAnviser(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(variabellonn.getAnviser()),
-            dfe);
+        return variabellonn.getAnviser()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public PersonalressursResource getKonterer(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(variabellonn.getKonterer()),
-            dfe);
+        return variabellonn.getKonterer()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public PersonalressursResource getAttestant(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(variabellonn.getAttestant()),
-            dfe);
+        return variabellonn.getAttestant()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public ArbeidsforholdResource getArbeidsforhold(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
-        return arbeidsforholdService.getArbeidsforholdResource(
-            Links.get(variabellonn.getArbeidsforhold()),
-            dfe);
+        return variabellonn.getArbeidsforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnResolver.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("administrasjonVariabellonnResolver")
@@ -37,42 +38,47 @@ public class VariabellonnResolver implements GraphQLResolver<VariabellonnResourc
 
     public LonnsartResource getLonnsart(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
         return variabellonn.getLonnsart()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> lonnsartService.getLonnsartResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> lonnsartService.getLonnsartResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public PersonalressursResource getAnviser(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
         return variabellonn.getAnviser()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public PersonalressursResource getKonterer(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
         return variabellonn.getKonterer()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public PersonalressursResource getAttestant(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
         return variabellonn.getAttestant()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public ArbeidsforholdResource getArbeidsforhold(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
         return variabellonn.getArbeidsforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.administrasjon.variabellonn;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.personal.VariabellonnResource;
-import no.fint.model.resource.administrasjon.personal.VariabellonnResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class VariabellonnService {
     @Autowired
     private Endpoints endpoints;
 
-    public VariabellonnResources getVariabellonnResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getAdministrasjonPersonal() + "/variabellonn",
-                    sinceTimeStamp),
-                VariabellonnResources.class,
-                dfe);
+    public VariabellonnResource getVariabellonnResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getVariabellonnResource(
+            endpoints.getAdministrasjonPersonal() 
+                + "/variabellonn/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public VariabellonnResource getVariabellonnResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/felles/adresse/AdresseResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/adresse/AdresseResolver.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("fellesAdresseResolver")
@@ -27,10 +28,11 @@ public class AdresseResolver implements GraphQLResolver<AdresseResource> {
 
     public LandkodeResource getLand(AdresseResource adresse, DataFetchingEnvironment dfe) {
         return adresse.getLand()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> landkodeService.getLandkodeResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> landkodeService.getLandkodeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/felles/adresse/AdresseResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/adresse/AdresseResolver.java
@@ -4,35 +4,33 @@ package no.fint.graphql.model.felles.adresse;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.felles.landkode.LandkodeService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.felles.kompleksedatatyper.AdresseResource;
-
-
 import no.fint.model.resource.felles.kodeverk.iso.LandkodeResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("fellesAdresseResolver")
 public class AdresseResolver implements GraphQLResolver<AdresseResource> {
-
 
     @Autowired
     private LandkodeService landkodeService;
 
 
     public LandkodeResource getLand(AdresseResource adresse, DataFetchingEnvironment dfe) {
-        return landkodeService.getLandkodeResource(
-            Links.get(adresse.getLand()),
-            dfe);
+        return adresse.getLand()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> landkodeService.getLandkodeResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/felles/fylke/FylkeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/fylke/FylkeQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.felles.fylke;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.felles.kodeverk.FylkeResource;
-import no.fint.model.resource.felles.kodeverk.FylkeResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("fellesFylkeQueryResolver")
 public class FylkeQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class FylkeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private FylkeService service;
 
-    public List<FylkeResource> getFylke(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        FylkeResources resources = service.getFylkeResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public FylkeResource getFylke(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getFylkeResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/fylke/FylkeResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/fylke/FylkeResolver.java
@@ -4,35 +4,33 @@ package no.fint.graphql.model.felles.fylke;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.felles.kommune.KommuneService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.felles.kodeverk.FylkeResource;
-
-
 import no.fint.model.resource.felles.kodeverk.KommuneResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("fellesFylkeResolver")
 public class FylkeResolver implements GraphQLResolver<FylkeResource> {
-
 
     @Autowired
     private KommuneService kommuneService;
 
 
-    public KommuneResource getKommune(FylkeResource fylke, DataFetchingEnvironment dfe) {
-        return kommuneService.getKommuneResource(
-            Links.get(fylke.getKommune()),
-            dfe);
+    public List<KommuneResource> getKommune(FylkeResource fylke, DataFetchingEnvironment dfe) {
+        return fylke.getKommune()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> kommuneService.getKommuneResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/felles/fylke/FylkeResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/fylke/FylkeResolver.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("fellesFylkeResolver")
@@ -27,10 +28,11 @@ public class FylkeResolver implements GraphQLResolver<FylkeResource> {
 
     public List<KommuneResource> getKommune(FylkeResource fylke, DataFetchingEnvironment dfe) {
         return fylke.getKommune()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> kommuneService.getKommuneResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> kommuneService.getKommuneResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/felles/fylke/FylkeService.java
+++ b/src/main/java/no/fint/graphql/model/felles/fylke/FylkeService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.felles.fylke;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.felles.kodeverk.FylkeResource;
-import no.fint.model.resource.felles.kodeverk.FylkeResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class FylkeService {
     @Autowired
     private Endpoints endpoints;
 
-    public FylkeResources getFylkeResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getFellesKodeverk() + "/fylke",
-                    sinceTimeStamp),
-                FylkeResources.class,
-                dfe);
+    public FylkeResource getFylkeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getFylkeResource(
+            endpoints.getFellesKodeverk() 
+                + "/fylke/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public FylkeResource getFylkeResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/felles/kjonn/KjonnQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/kjonn/KjonnQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.felles.kjonn;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.felles.kodeverk.iso.KjonnResource;
-import no.fint.model.resource.felles.kodeverk.iso.KjonnResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("fellesKjonnQueryResolver")
 public class KjonnQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class KjonnQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private KjonnService service;
 
-    public List<KjonnResource> getKjonn(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        KjonnResources resources = service.getKjonnResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public KjonnResource getKjonn(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getKjonnResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/kjonn/KjonnService.java
+++ b/src/main/java/no/fint/graphql/model/felles/kjonn/KjonnService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.felles.kjonn;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.felles.kodeverk.iso.KjonnResource;
-import no.fint.model.resource.felles.kodeverk.iso.KjonnResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class KjonnService {
     @Autowired
     private Endpoints endpoints;
 
-    public KjonnResources getKjonnResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getFellesKodeverkIso() + "/kjonn",
-                    sinceTimeStamp),
-                KjonnResources.class,
-                dfe);
+    public KjonnResource getKjonnResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getKjonnResource(
+            endpoints.getFellesKodeverkIso() 
+                + "/kjonn/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public KjonnResource getKjonnResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/felles/kommune/KommuneQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/kommune/KommuneQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.felles.kommune;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.felles.kodeverk.KommuneResource;
-import no.fint.model.resource.felles.kodeverk.KommuneResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("fellesKommuneQueryResolver")
 public class KommuneQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class KommuneQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private KommuneService service;
 
-    public List<KommuneResource> getKommune(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        KommuneResources resources = service.getKommuneResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public KommuneResource getKommune(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getKommuneResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/kommune/KommuneResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/kommune/KommuneResolver.java
@@ -4,35 +4,33 @@ package no.fint.graphql.model.felles.kommune;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.felles.fylke.FylkeService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.felles.kodeverk.KommuneResource;
-
-
 import no.fint.model.resource.felles.kodeverk.FylkeResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("fellesKommuneResolver")
 public class KommuneResolver implements GraphQLResolver<KommuneResource> {
-
 
     @Autowired
     private FylkeService fylkeService;
 
 
     public FylkeResource getFylke(KommuneResource kommune, DataFetchingEnvironment dfe) {
-        return fylkeService.getFylkeResource(
-            Links.get(kommune.getFylke()),
-            dfe);
+        return kommune.getFylke()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> fylkeService.getFylkeResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/felles/kommune/KommuneResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/kommune/KommuneResolver.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("fellesKommuneResolver")
@@ -27,10 +28,11 @@ public class KommuneResolver implements GraphQLResolver<KommuneResource> {
 
     public FylkeResource getFylke(KommuneResource kommune, DataFetchingEnvironment dfe) {
         return kommune.getFylke()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> fylkeService.getFylkeResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fylkeService.getFylkeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/felles/kommune/KommuneService.java
+++ b/src/main/java/no/fint/graphql/model/felles/kommune/KommuneService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.felles.kommune;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.felles.kodeverk.KommuneResource;
-import no.fint.model.resource.felles.kodeverk.KommuneResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class KommuneService {
     @Autowired
     private Endpoints endpoints;
 
-    public KommuneResources getKommuneResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getFellesKodeverk() + "/kommune",
-                    sinceTimeStamp),
-                KommuneResources.class,
-                dfe);
+    public KommuneResource getKommuneResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getKommuneResource(
+            endpoints.getFellesKodeverk() 
+                + "/kommune/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public KommuneResource getKommuneResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.felles.kontaktperson;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.felles.KontaktpersonResource;
-import no.fint.model.resource.felles.KontaktpersonResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("fellesKontaktpersonQueryResolver")
 public class KontaktpersonQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class KontaktpersonQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private KontaktpersonService service;
 
-    public List<KontaktpersonResource> getKontaktperson(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        KontaktpersonResources resources = service.getKontaktpersonResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public KontaktpersonResource getKontaktperson(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getKontaktpersonResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonResolver.java
@@ -4,41 +4,41 @@ package no.fint.graphql.model.felles.kontaktperson;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.felles.person.PersonService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.felles.KontaktpersonResource;
-
-
 import no.fint.model.resource.felles.PersonResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("fellesKontaktpersonResolver")
 public class KontaktpersonResolver implements GraphQLResolver<KontaktpersonResource> {
-
 
     @Autowired
     private PersonService personService;
 
 
     public PersonResource getKontaktperson(KontaktpersonResource kontaktperson, DataFetchingEnvironment dfe) {
-        return personService.getPersonResource(
-            Links.get(kontaktperson.getKontaktperson()),
-            dfe);
+        return kontaktperson.getKontaktperson()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personService.getPersonResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public PersonResource getPerson(KontaktpersonResource kontaktperson, DataFetchingEnvironment dfe) {
-        return personService.getPersonResource(
-            Links.get(kontaktperson.getPerson()),
-            dfe);
+        return kontaktperson.getPerson()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personService.getPersonResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonResolver.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("fellesKontaktpersonResolver")
@@ -27,18 +28,20 @@ public class KontaktpersonResolver implements GraphQLResolver<KontaktpersonResou
 
     public PersonResource getKontaktperson(KontaktpersonResource kontaktperson, DataFetchingEnvironment dfe) {
         return kontaktperson.getKontaktperson()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personService.getPersonResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personService.getPersonResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public PersonResource getPerson(KontaktpersonResource kontaktperson, DataFetchingEnvironment dfe) {
         return kontaktperson.getPerson()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personService.getPersonResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personService.getPersonResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonService.java
+++ b/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.felles.kontaktperson;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.felles.KontaktpersonResource;
-import no.fint.model.resource.felles.KontaktpersonResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class KontaktpersonService {
     @Autowired
     private Endpoints endpoints;
 
-    public KontaktpersonResources getKontaktpersonResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getFelles() + "/kontaktperson",
-                    sinceTimeStamp),
-                KontaktpersonResources.class,
-                dfe);
+    public KontaktpersonResource getKontaktpersonResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getKontaktpersonResource(
+            endpoints.getFelles() 
+                + "/kontaktperson/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public KontaktpersonResource getKontaktpersonResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/felles/landkode/LandkodeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/landkode/LandkodeQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.felles.landkode;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.felles.kodeverk.iso.LandkodeResource;
-import no.fint.model.resource.felles.kodeverk.iso.LandkodeResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("fellesLandkodeQueryResolver")
 public class LandkodeQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class LandkodeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private LandkodeService service;
 
-    public List<LandkodeResource> getLandkode(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        LandkodeResources resources = service.getLandkodeResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public LandkodeResource getLandkode(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getLandkodeResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/landkode/LandkodeService.java
+++ b/src/main/java/no/fint/graphql/model/felles/landkode/LandkodeService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.felles.landkode;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.felles.kodeverk.iso.LandkodeResource;
-import no.fint.model.resource.felles.kodeverk.iso.LandkodeResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class LandkodeService {
     @Autowired
     private Endpoints endpoints;
 
-    public LandkodeResources getLandkodeResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getFellesKodeverkIso() + "/landkode",
-                    sinceTimeStamp),
-                LandkodeResources.class,
-                dfe);
+    public LandkodeResource getLandkodeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getLandkodeResource(
+            endpoints.getFellesKodeverkIso() 
+                + "/landkode/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public LandkodeResource getLandkodeResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/felles/person/PersonQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/person/PersonQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.felles.person;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.felles.PersonResource;
-import no.fint.model.resource.felles.PersonResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("fellesPersonQueryResolver")
 public class PersonQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class PersonQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private PersonService service;
 
-    public List<PersonResource> getPerson(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        PersonResources resources = service.getPersonResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public PersonResource getPerson(
+            String fodselsnummer,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(fodselsnummer)) {
+            return service.getPersonResourceById("fodselsnummer", fodselsnummer, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/person/PersonResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/person/PersonResolver.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("fellesPersonResolver")
@@ -52,58 +53,65 @@ public class PersonResolver implements GraphQLResolver<PersonResource> {
 
     public List<LandkodeResource> getStatsborgerskap(PersonResource person, DataFetchingEnvironment dfe) {
         return person.getStatsborgerskap()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> landkodeService.getLandkodeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> landkodeService.getLandkodeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public KjonnResource getKjonn(PersonResource person, DataFetchingEnvironment dfe) {
         return person.getKjonn()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> kjonnService.getKjonnResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> kjonnService.getKjonnResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public SprakResource getMalform(PersonResource person, DataFetchingEnvironment dfe) {
         return person.getMalform()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> sprakService.getSprakResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> sprakService.getSprakResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public PersonalressursResource getPersonalressurs(PersonResource person, DataFetchingEnvironment dfe) {
         return person.getPersonalressurs()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public SprakResource getMorsmal(PersonResource person, DataFetchingEnvironment dfe) {
         return person.getMorsmal()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> sprakService.getSprakResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> sprakService.getSprakResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<KontaktpersonResource> getParorende(PersonResource person, DataFetchingEnvironment dfe) {
         return person.getParorende()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> kontaktpersonService.getKontaktpersonResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> kontaktpersonService.getKontaktpersonResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public ElevResource getElev(PersonResource person, DataFetchingEnvironment dfe) {
         return person.getElev()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> elevService.getElevResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> elevService.getElevResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/felles/person/PersonResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/person/PersonResolver.java
@@ -4,10 +4,6 @@ package no.fint.graphql.model.felles.person;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.felles.landkode.LandkodeService;
 import no.fint.graphql.model.felles.kjonn.KjonnService;
@@ -17,9 +13,8 @@ import no.fint.graphql.model.felles.kontaktperson.KontaktpersonService;
 import no.fint.graphql.model.utdanning.elev.ElevService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.felles.PersonResource;
-
-
 import no.fint.model.resource.felles.kodeverk.iso.LandkodeResource;
 import no.fint.model.resource.felles.kodeverk.iso.KjonnResource;
 import no.fint.model.resource.felles.kodeverk.iso.SprakResource;
@@ -27,13 +22,14 @@ import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
 import no.fint.model.resource.felles.KontaktpersonResource;
 import no.fint.model.resource.utdanning.elev.ElevResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("fellesPersonResolver")
 public class PersonResolver implements GraphQLResolver<PersonResource> {
-
 
     @Autowired
     private LandkodeService landkodeService;
@@ -54,46 +50,60 @@ public class PersonResolver implements GraphQLResolver<PersonResource> {
     private ElevService elevService;
 
 
-    public LandkodeResource getStatsborgerskap(PersonResource person, DataFetchingEnvironment dfe) {
-        return landkodeService.getLandkodeResource(
-            Links.get(person.getStatsborgerskap()),
-            dfe);
+    public List<LandkodeResource> getStatsborgerskap(PersonResource person, DataFetchingEnvironment dfe) {
+        return person.getStatsborgerskap()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> landkodeService.getLandkodeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
     public KjonnResource getKjonn(PersonResource person, DataFetchingEnvironment dfe) {
-        return kjonnService.getKjonnResource(
-            Links.get(person.getKjonn()),
-            dfe);
+        return person.getKjonn()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> kjonnService.getKjonnResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public SprakResource getMalform(PersonResource person, DataFetchingEnvironment dfe) {
-        return sprakService.getSprakResource(
-            Links.get(person.getMalform()),
-            dfe);
+        return person.getMalform()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> sprakService.getSprakResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public PersonalressursResource getPersonalressurs(PersonResource person, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(person.getPersonalressurs()),
-            dfe);
+        return person.getPersonalressurs()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public SprakResource getMorsmal(PersonResource person, DataFetchingEnvironment dfe) {
-        return sprakService.getSprakResource(
-            Links.get(person.getMorsmal()),
-            dfe);
+        return person.getMorsmal()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> sprakService.getSprakResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public KontaktpersonResource getParorende(PersonResource person, DataFetchingEnvironment dfe) {
-        return kontaktpersonService.getKontaktpersonResource(
-            Links.get(person.getParorende()),
-            dfe);
+    public List<KontaktpersonResource> getParorende(PersonResource person, DataFetchingEnvironment dfe) {
+        return person.getParorende()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> kontaktpersonService.getKontaktpersonResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
     public ElevResource getElev(PersonResource person, DataFetchingEnvironment dfe) {
-        return elevService.getElevResource(
-            Links.get(person.getElev()),
-            dfe);
+        return person.getElev()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> elevService.getElevResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/felles/person/PersonService.java
+++ b/src/main/java/no/fint/graphql/model/felles/person/PersonService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.felles.person;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.felles.PersonResource;
-import no.fint.model.resource.felles.PersonResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class PersonService {
     @Autowired
     private Endpoints endpoints;
 
-    public PersonResources getPersonResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getFelles() + "/person",
-                    sinceTimeStamp),
-                PersonResources.class,
-                dfe);
+    public PersonResource getPersonResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getPersonResource(
+            endpoints.getFelles() 
+                + "/person/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public PersonResource getPersonResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/felles/sprak/SprakQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/sprak/SprakQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.felles.sprak;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.felles.kodeverk.iso.SprakResource;
-import no.fint.model.resource.felles.kodeverk.iso.SprakResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("fellesSprakQueryResolver")
 public class SprakQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class SprakQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private SprakService service;
 
-    public List<SprakResource> getSprak(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        SprakResources resources = service.getSprakResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public SprakResource getSprak(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getSprakResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/sprak/SprakService.java
+++ b/src/main/java/no/fint/graphql/model/felles/sprak/SprakService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.felles.sprak;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.felles.kodeverk.iso.SprakResource;
-import no.fint.model.resource.felles.kodeverk.iso.SprakResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class SprakService {
     @Autowired
     private Endpoints endpoints;
 
-    public SprakResources getSprakResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getFellesKodeverkIso() + "/sprak",
-                    sinceTimeStamp),
-                SprakResources.class,
-                dfe);
+    public SprakResource getSprakResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getSprakResource(
+            endpoints.getFellesKodeverkIso() 
+                + "/sprak/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public SprakResource getSprakResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/arstrinn/ArstrinnQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/arstrinn/ArstrinnQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.arstrinn;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.utdanningsprogram.ArstrinnResource;
-import no.fint.model.resource.utdanning.utdanningsprogram.ArstrinnResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningArstrinnQueryResolver")
 public class ArstrinnQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class ArstrinnQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ArstrinnService service;
 
-    public List<ArstrinnResource> getArstrinn(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        ArstrinnResources resources = service.getArstrinnResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public ArstrinnResource getArstrinn(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getArstrinnResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/arstrinn/ArstrinnResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/arstrinn/ArstrinnResolver.java
@@ -4,30 +4,26 @@ package no.fint.graphql.model.utdanning.arstrinn;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.utdanning.programomrade.ProgramomradeService;
 import no.fint.graphql.model.utdanning.basisgruppe.BasisgruppeService;
 import no.fint.graphql.model.utdanning.medlemskap.MedlemskapService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.utdanningsprogram.ArstrinnResource;
-
-
 import no.fint.model.resource.utdanning.utdanningsprogram.ProgramomradeResource;
 import no.fint.model.resource.utdanning.elev.BasisgruppeResource;
 import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningArstrinnResolver")
 public class ArstrinnResolver implements GraphQLResolver<ArstrinnResource> {
-
 
     @Autowired
     private ProgramomradeService programomradeService;
@@ -39,22 +35,28 @@ public class ArstrinnResolver implements GraphQLResolver<ArstrinnResource> {
     private MedlemskapService medlemskapService;
 
 
-    public ProgramomradeResource getProgramomrade(ArstrinnResource arstrinn, DataFetchingEnvironment dfe) {
-        return programomradeService.getProgramomradeResource(
-            Links.get(arstrinn.getProgramomrade()),
-            dfe);
+    public List<ProgramomradeResource> getProgramomrade(ArstrinnResource arstrinn, DataFetchingEnvironment dfe) {
+        return arstrinn.getProgramomrade()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> programomradeService.getProgramomradeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public BasisgruppeResource getBasisgruppe(ArstrinnResource arstrinn, DataFetchingEnvironment dfe) {
-        return basisgruppeService.getBasisgruppeResource(
-            Links.get(arstrinn.getBasisgruppe()),
-            dfe);
+    public List<BasisgruppeResource> getBasisgruppe(ArstrinnResource arstrinn, DataFetchingEnvironment dfe) {
+        return arstrinn.getBasisgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public MedlemskapResource getMedlemskap(ArstrinnResource arstrinn, DataFetchingEnvironment dfe) {
-        return medlemskapService.getMedlemskapResource(
-            Links.get(arstrinn.getMedlemskap()),
-            dfe);
+    public List<MedlemskapResource> getMedlemskap(ArstrinnResource arstrinn, DataFetchingEnvironment dfe) {
+        return arstrinn.getMedlemskap()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/arstrinn/ArstrinnResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/arstrinn/ArstrinnResolver.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningArstrinnResolver")
@@ -37,26 +38,29 @@ public class ArstrinnResolver implements GraphQLResolver<ArstrinnResource> {
 
     public List<ProgramomradeResource> getProgramomrade(ArstrinnResource arstrinn, DataFetchingEnvironment dfe) {
         return arstrinn.getProgramomrade()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> programomradeService.getProgramomradeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> programomradeService.getProgramomradeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<BasisgruppeResource> getBasisgruppe(ArstrinnResource arstrinn, DataFetchingEnvironment dfe) {
         return arstrinn.getBasisgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<MedlemskapResource> getMedlemskap(ArstrinnResource arstrinn, DataFetchingEnvironment dfe) {
         return arstrinn.getMedlemskap()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/arstrinn/ArstrinnService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/arstrinn/ArstrinnService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.arstrinn;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.utdanningsprogram.ArstrinnResource;
-import no.fint.model.resource.utdanning.utdanningsprogram.ArstrinnResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class ArstrinnService {
     @Autowired
     private Endpoints endpoints;
 
-    public ArstrinnResources getArstrinnResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningUtdanningsprogram() + "/arstrinn",
-                    sinceTimeStamp),
-                ArstrinnResources.class,
-                dfe);
+    public ArstrinnResource getArstrinnResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getArstrinnResource(
+            endpoints.getUtdanningUtdanningsprogram() 
+                + "/arstrinn/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public ArstrinnResource getArstrinnResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.basisgruppe;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.elev.BasisgruppeResource;
-import no.fint.model.resource.utdanning.elev.BasisgruppeResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningBasisgruppeQueryResolver")
 public class BasisgruppeQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class BasisgruppeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private BasisgruppeService service;
 
-    public List<BasisgruppeResource> getBasisgruppe(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        BasisgruppeResources resources = service.getBasisgruppeResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public BasisgruppeResource getBasisgruppe(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getBasisgruppeResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeResolver.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningBasisgruppeResolver")
@@ -52,50 +53,56 @@ public class BasisgruppeResolver implements GraphQLResolver<BasisgruppeResource>
 
     public ArstrinnResource getTrinn(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
         return basisgruppe.getTrinn()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> arstrinnService.getArstrinnResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> arstrinnService.getArstrinnResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public SkoleResource getSkole(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
         return basisgruppe.getSkole()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> skoleService.getSkoleResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> skoleService.getSkoleResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<UndervisningsforholdResource> getUndervisningsforhold(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
         return basisgruppe.getUndervisningsforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<ElevforholdResource> getElevforhold(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
         return basisgruppe.getElevforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> elevforholdService.getElevforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> elevforholdService.getElevforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<KontaktlarergruppeResource> getKontaktlarergruppe(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
         return basisgruppe.getKontaktlarergruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<MedlemskapResource> getMedlemskap(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
         return basisgruppe.getMedlemskap()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeResolver.java
@@ -4,10 +4,6 @@ package no.fint.graphql.model.utdanning.basisgruppe;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.utdanning.arstrinn.ArstrinnService;
 import no.fint.graphql.model.utdanning.skole.SkoleService;
@@ -17,9 +13,8 @@ import no.fint.graphql.model.utdanning.kontaktlarergruppe.KontaktlarergruppeServ
 import no.fint.graphql.model.utdanning.medlemskap.MedlemskapService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.elev.BasisgruppeResource;
-
-
 import no.fint.model.resource.utdanning.utdanningsprogram.ArstrinnResource;
 import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
 import no.fint.model.resource.utdanning.elev.UndervisningsforholdResource;
@@ -27,13 +22,14 @@ import no.fint.model.resource.utdanning.elev.ElevforholdResource;
 import no.fint.model.resource.utdanning.elev.KontaktlarergruppeResource;
 import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningBasisgruppeResolver")
 public class BasisgruppeResolver implements GraphQLResolver<BasisgruppeResource> {
-
 
     @Autowired
     private ArstrinnService arstrinnService;
@@ -55,39 +51,51 @@ public class BasisgruppeResolver implements GraphQLResolver<BasisgruppeResource>
 
 
     public ArstrinnResource getTrinn(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
-        return arstrinnService.getArstrinnResource(
-            Links.get(basisgruppe.getTrinn()),
-            dfe);
+        return basisgruppe.getTrinn()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> arstrinnService.getArstrinnResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public SkoleResource getSkole(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
-        return skoleService.getSkoleResource(
-            Links.get(basisgruppe.getSkole()),
-            dfe);
+        return basisgruppe.getSkole()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> skoleService.getSkoleResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public UndervisningsforholdResource getUndervisningsforhold(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
-        return undervisningsforholdService.getUndervisningsforholdResource(
-            Links.get(basisgruppe.getUndervisningsforhold()),
-            dfe);
+    public List<UndervisningsforholdResource> getUndervisningsforhold(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
+        return basisgruppe.getUndervisningsforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public ElevforholdResource getElevforhold(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
-        return elevforholdService.getElevforholdResource(
-            Links.get(basisgruppe.getElevforhold()),
-            dfe);
+    public List<ElevforholdResource> getElevforhold(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
+        return basisgruppe.getElevforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> elevforholdService.getElevforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public KontaktlarergruppeResource getKontaktlarergruppe(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
-        return kontaktlarergruppeService.getKontaktlarergruppeResource(
-            Links.get(basisgruppe.getKontaktlarergruppe()),
-            dfe);
+    public List<KontaktlarergruppeResource> getKontaktlarergruppe(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
+        return basisgruppe.getKontaktlarergruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public MedlemskapResource getMedlemskap(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
-        return medlemskapService.getMedlemskapResource(
-            Links.get(basisgruppe.getMedlemskap()),
-            dfe);
+    public List<MedlemskapResource> getMedlemskap(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
+        return basisgruppe.getMedlemskap()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.basisgruppe;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.elev.BasisgruppeResource;
-import no.fint.model.resource.utdanning.elev.BasisgruppeResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class BasisgruppeService {
     @Autowired
     private Endpoints endpoints;
 
-    public BasisgruppeResources getBasisgruppeResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningElev() + "/basisgruppe",
-                    sinceTimeStamp),
-                BasisgruppeResources.class,
-                dfe);
+    public BasisgruppeResource getBasisgruppeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getBasisgruppeResource(
+            endpoints.getUtdanningElev() 
+                + "/basisgruppe/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public BasisgruppeResource getBasisgruppeResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.eksamensgruppe;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.vurdering.EksamensgruppeResource;
-import no.fint.model.resource.utdanning.vurdering.EksamensgruppeResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningEksamensgruppeQueryResolver")
 public class EksamensgruppeQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class EksamensgruppeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private EksamensgruppeService service;
 
-    public List<EksamensgruppeResource> getEksamensgruppe(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        EksamensgruppeResources resources = service.getEksamensgruppeResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public EksamensgruppeResource getEksamensgruppe(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getEksamensgruppeResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeResolver.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningEksamensgruppeResolver")
@@ -47,42 +48,47 @@ public class EksamensgruppeResolver implements GraphQLResolver<EksamensgruppeRes
 
     public FagResource getFag(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
         return eksamensgruppe.getFag()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> fagService.getFagResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fagService.getFagResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public SkoleResource getSkole(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
         return eksamensgruppe.getSkole()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> skoleService.getSkoleResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> skoleService.getSkoleResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<ElevforholdResource> getElevforhold(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
         return eksamensgruppe.getElevforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> elevforholdService.getElevforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> elevforholdService.getElevforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<UndervisningsforholdResource> getUndervisningsforhold(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
         return eksamensgruppe.getUndervisningsforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<MedlemskapResource> getMedlemskap(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
         return eksamensgruppe.getMedlemskap()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeResolver.java
@@ -4,10 +4,6 @@ package no.fint.graphql.model.utdanning.eksamensgruppe;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.utdanning.fag.FagService;
 import no.fint.graphql.model.utdanning.skole.SkoleService;
@@ -16,22 +12,22 @@ import no.fint.graphql.model.utdanning.undervisningsforhold.Undervisningsforhold
 import no.fint.graphql.model.utdanning.medlemskap.MedlemskapService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.vurdering.EksamensgruppeResource;
-
-
 import no.fint.model.resource.utdanning.timeplan.FagResource;
 import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
 import no.fint.model.resource.utdanning.elev.ElevforholdResource;
 import no.fint.model.resource.utdanning.elev.UndervisningsforholdResource;
 import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningEksamensgruppeResolver")
 public class EksamensgruppeResolver implements GraphQLResolver<EksamensgruppeResource> {
-
 
     @Autowired
     private FagService fagService;
@@ -50,33 +46,43 @@ public class EksamensgruppeResolver implements GraphQLResolver<EksamensgruppeRes
 
 
     public FagResource getFag(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
-        return fagService.getFagResource(
-            Links.get(eksamensgruppe.getFag()),
-            dfe);
+        return eksamensgruppe.getFag()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> fagService.getFagResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public SkoleResource getSkole(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
-        return skoleService.getSkoleResource(
-            Links.get(eksamensgruppe.getSkole()),
-            dfe);
+        return eksamensgruppe.getSkole()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> skoleService.getSkoleResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public ElevforholdResource getElevforhold(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
-        return elevforholdService.getElevforholdResource(
-            Links.get(eksamensgruppe.getElevforhold()),
-            dfe);
+    public List<ElevforholdResource> getElevforhold(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
+        return eksamensgruppe.getElevforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> elevforholdService.getElevforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public UndervisningsforholdResource getUndervisningsforhold(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
-        return undervisningsforholdService.getUndervisningsforholdResource(
-            Links.get(eksamensgruppe.getUndervisningsforhold()),
-            dfe);
+    public List<UndervisningsforholdResource> getUndervisningsforhold(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
+        return eksamensgruppe.getUndervisningsforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public MedlemskapResource getMedlemskap(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
-        return medlemskapService.getMedlemskapResource(
-            Links.get(eksamensgruppe.getMedlemskap()),
-            dfe);
+    public List<MedlemskapResource> getMedlemskap(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
+        return eksamensgruppe.getMedlemskap()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.eksamensgruppe;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.vurdering.EksamensgruppeResource;
-import no.fint.model.resource.utdanning.vurdering.EksamensgruppeResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class EksamensgruppeService {
     @Autowired
     private Endpoints endpoints;
 
-    public EksamensgruppeResources getEksamensgruppeResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningVurdering() + "/eksamensgruppe",
-                    sinceTimeStamp),
-                EksamensgruppeResources.class,
-                dfe);
+    public EksamensgruppeResource getEksamensgruppeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getEksamensgruppeResource(
+            endpoints.getUtdanningVurdering() 
+                + "/eksamensgruppe/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public EksamensgruppeResource getEksamensgruppeResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/elev/ElevQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elev/ElevQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.elev;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.elev.ElevResource;
-import no.fint.model.resource.utdanning.elev.ElevResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningElevQueryResolver")
 public class ElevQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,24 @@ public class ElevQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ElevService service;
 
-    public List<ElevResource> getElev(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        ElevResources resources = service.getElevResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public ElevResource getElev(
+            String brukernavn,
+            String elevnummer,
+            String feidenavn,
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(brukernavn)) {
+            return service.getElevResourceById("brukernavn", brukernavn, dfe);
+        }
+        if (StringUtils.isNotEmpty(elevnummer)) {
+            return service.getElevResourceById("elevnummer", elevnummer, dfe);
+        }
+        if (StringUtils.isNotEmpty(feidenavn)) {
+            return service.getElevResourceById("feidenavn", feidenavn, dfe);
+        }
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getElevResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/elev/ElevResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elev/ElevResolver.java
@@ -4,28 +4,24 @@ package no.fint.graphql.model.utdanning.elev;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.felles.person.PersonService;
 import no.fint.graphql.model.utdanning.elevforhold.ElevforholdService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.elev.ElevResource;
-
-
 import no.fint.model.resource.felles.PersonResource;
 import no.fint.model.resource.utdanning.elev.ElevforholdResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningElevResolver")
 public class ElevResolver implements GraphQLResolver<ElevResource> {
-
 
     @Autowired
     private PersonService personService;
@@ -35,15 +31,19 @@ public class ElevResolver implements GraphQLResolver<ElevResource> {
 
 
     public PersonResource getPerson(ElevResource elev, DataFetchingEnvironment dfe) {
-        return personService.getPersonResource(
-            Links.get(elev.getPerson()),
-            dfe);
+        return elev.getPerson()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personService.getPersonResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public ElevforholdResource getElevforhold(ElevResource elev, DataFetchingEnvironment dfe) {
-        return elevforholdService.getElevforholdResource(
-            Links.get(elev.getElevforhold()),
-            dfe);
+    public List<ElevforholdResource> getElevforhold(ElevResource elev, DataFetchingEnvironment dfe) {
+        return elev.getElevforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> elevforholdService.getElevforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/elev/ElevResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elev/ElevResolver.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningElevResolver")
@@ -32,18 +33,20 @@ public class ElevResolver implements GraphQLResolver<ElevResource> {
 
     public PersonResource getPerson(ElevResource elev, DataFetchingEnvironment dfe) {
         return elev.getPerson()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personService.getPersonResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personService.getPersonResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<ElevforholdResource> getElevforhold(ElevResource elev, DataFetchingEnvironment dfe) {
         return elev.getElevforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> elevforholdService.getElevforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> elevforholdService.getElevforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/elev/ElevService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elev/ElevService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.elev;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.elev.ElevResource;
-import no.fint.model.resource.utdanning.elev.ElevResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class ElevService {
     @Autowired
     private Endpoints endpoints;
 
-    public ElevResources getElevResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningElev() + "/elev",
-                    sinceTimeStamp),
-                ElevResources.class,
-                dfe);
+    public ElevResource getElevResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getElevResource(
+            endpoints.getUtdanningElev() 
+                + "/elev/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public ElevResource getElevResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.elevforhold;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.elev.ElevforholdResource;
-import no.fint.model.resource.utdanning.elev.ElevforholdResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningElevforholdQueryResolver")
 public class ElevforholdQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class ElevforholdQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ElevforholdService service;
 
-    public List<ElevforholdResource> getElevforhold(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        ElevforholdResources resources = service.getElevforholdResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public ElevforholdResource getElevforhold(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getElevforholdResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdResolver.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningElevforholdResolver")
@@ -67,74 +68,83 @@ public class ElevforholdResolver implements GraphQLResolver<ElevforholdResource>
 
     public List<BasisgruppeResource> getBasisgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
         return elevforhold.getBasisgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public ElevResource getElev(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
         return elevforhold.getElev()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> elevService.getElevResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> elevService.getElevResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public ElevkategoriResource getKategori(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
         return elevforhold.getKategori()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> elevkategoriService.getElevkategoriResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> elevkategoriService.getElevkategoriResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public SkoleResource getSkole(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
         return elevforhold.getSkole()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> skoleService.getSkoleResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> skoleService.getSkoleResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<EksamensgruppeResource> getEksamensgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
         return elevforhold.getEksamensgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<KontaktlarergruppeResource> getKontaktlarergruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
         return elevforhold.getKontaktlarergruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<UndervisningsgruppeResource> getUndervisningsgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
         return elevforhold.getUndervisningsgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<VurderingResource> getVurdering(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
         return elevforhold.getVurdering()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> vurderingService.getVurderingResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> vurderingService.getVurderingResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<MedlemskapResource> getMedlemskap(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
         return elevforhold.getMedlemskap()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdResolver.java
@@ -4,10 +4,6 @@ package no.fint.graphql.model.utdanning.elevforhold;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.utdanning.basisgruppe.BasisgruppeService;
 import no.fint.graphql.model.utdanning.elev.ElevService;
@@ -20,9 +16,8 @@ import no.fint.graphql.model.utdanning.vurdering.VurderingService;
 import no.fint.graphql.model.utdanning.medlemskap.MedlemskapService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.elev.ElevforholdResource;
-
-
 import no.fint.model.resource.utdanning.elev.BasisgruppeResource;
 import no.fint.model.resource.utdanning.elev.ElevResource;
 import no.fint.model.resource.utdanning.kodeverk.ElevkategoriResource;
@@ -33,13 +28,14 @@ import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResource;
 import no.fint.model.resource.utdanning.vurdering.VurderingResource;
 import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningElevforholdResolver")
 public class ElevforholdResolver implements GraphQLResolver<ElevforholdResource> {
-
 
     @Autowired
     private BasisgruppeService basisgruppeService;
@@ -69,58 +65,76 @@ public class ElevforholdResolver implements GraphQLResolver<ElevforholdResource>
     private MedlemskapService medlemskapService;
 
 
-    public BasisgruppeResource getBasisgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return basisgruppeService.getBasisgruppeResource(
-            Links.get(elevforhold.getBasisgruppe()),
-            dfe);
+    public List<BasisgruppeResource> getBasisgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
+        return elevforhold.getBasisgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
     public ElevResource getElev(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return elevService.getElevResource(
-            Links.get(elevforhold.getElev()),
-            dfe);
+        return elevforhold.getElev()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> elevService.getElevResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public ElevkategoriResource getKategori(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return elevkategoriService.getElevkategoriResource(
-            Links.get(elevforhold.getKategori()),
-            dfe);
+        return elevforhold.getKategori()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> elevkategoriService.getElevkategoriResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public SkoleResource getSkole(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return skoleService.getSkoleResource(
-            Links.get(elevforhold.getSkole()),
-            dfe);
+        return elevforhold.getSkole()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> skoleService.getSkoleResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public EksamensgruppeResource getEksamensgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return eksamensgruppeService.getEksamensgruppeResource(
-            Links.get(elevforhold.getEksamensgruppe()),
-            dfe);
+    public List<EksamensgruppeResource> getEksamensgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
+        return elevforhold.getEksamensgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public KontaktlarergruppeResource getKontaktlarergruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return kontaktlarergruppeService.getKontaktlarergruppeResource(
-            Links.get(elevforhold.getKontaktlarergruppe()),
-            dfe);
+    public List<KontaktlarergruppeResource> getKontaktlarergruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
+        return elevforhold.getKontaktlarergruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public UndervisningsgruppeResource getUndervisningsgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return undervisningsgruppeService.getUndervisningsgruppeResource(
-            Links.get(elevforhold.getUndervisningsgruppe()),
-            dfe);
+    public List<UndervisningsgruppeResource> getUndervisningsgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
+        return elevforhold.getUndervisningsgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public VurderingResource getVurdering(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return vurderingService.getVurderingResource(
-            Links.get(elevforhold.getVurdering()),
-            dfe);
+    public List<VurderingResource> getVurdering(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
+        return elevforhold.getVurdering()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> vurderingService.getVurderingResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public MedlemskapResource getMedlemskap(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return medlemskapService.getMedlemskapResource(
-            Links.get(elevforhold.getMedlemskap()),
-            dfe);
+    public List<MedlemskapResource> getMedlemskap(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
+        return elevforhold.getMedlemskap()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.elevforhold;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.elev.ElevforholdResource;
-import no.fint.model.resource.utdanning.elev.ElevforholdResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class ElevforholdService {
     @Autowired
     private Endpoints endpoints;
 
-    public ElevforholdResources getElevforholdResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningElev() + "/elevforhold",
-                    sinceTimeStamp),
-                ElevforholdResources.class,
-                dfe);
+    public ElevforholdResource getElevforholdResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getElevforholdResource(
+            endpoints.getUtdanningElev() 
+                + "/elevforhold/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public ElevforholdResource getElevforholdResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/elevkategori/ElevkategoriQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elevkategori/ElevkategoriQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.elevkategori;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.kodeverk.ElevkategoriResource;
-import no.fint.model.resource.utdanning.kodeverk.ElevkategoriResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningElevkategoriQueryResolver")
 public class ElevkategoriQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class ElevkategoriQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ElevkategoriService service;
 
-    public List<ElevkategoriResource> getElevkategori(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        ElevkategoriResources resources = service.getElevkategoriResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public ElevkategoriResource getElevkategori(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getElevkategoriResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/elevkategori/ElevkategoriService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elevkategori/ElevkategoriService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.elevkategori;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.kodeverk.ElevkategoriResource;
-import no.fint.model.resource.utdanning.kodeverk.ElevkategoriResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class ElevkategoriService {
     @Autowired
     private Endpoints endpoints;
 
-    public ElevkategoriResources getElevkategoriResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningKodeverk() + "/elevkategori",
-                    sinceTimeStamp),
-                ElevkategoriResources.class,
-                dfe);
+    public ElevkategoriResource getElevkategoriResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getElevkategoriResource(
+            endpoints.getUtdanningKodeverk() 
+                + "/elevkategori/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public ElevkategoriResource getElevkategoriResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/fag/FagQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/fag/FagQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.fag;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.timeplan.FagResource;
-import no.fint.model.resource.utdanning.timeplan.FagResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningFagQueryResolver")
 public class FagQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class FagQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private FagService service;
 
-    public List<FagResource> getFag(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        FagResources resources = service.getFagResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public FagResource getFag(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getFagResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/fag/FagResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/fag/FagResolver.java
@@ -4,10 +4,6 @@ package no.fint.graphql.model.utdanning.fag;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.utdanning.programomrade.ProgramomradeService;
 import no.fint.graphql.model.utdanning.skole.SkoleService;
@@ -16,22 +12,22 @@ import no.fint.graphql.model.utdanning.eksamensgruppe.EksamensgruppeService;
 import no.fint.graphql.model.utdanning.medlemskap.MedlemskapService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.timeplan.FagResource;
-
-
 import no.fint.model.resource.utdanning.utdanningsprogram.ProgramomradeResource;
 import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
 import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResource;
 import no.fint.model.resource.utdanning.vurdering.EksamensgruppeResource;
 import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningFagResolver")
 public class FagResolver implements GraphQLResolver<FagResource> {
-
 
     @Autowired
     private ProgramomradeService programomradeService;
@@ -49,34 +45,44 @@ public class FagResolver implements GraphQLResolver<FagResource> {
     private MedlemskapService medlemskapService;
 
 
-    public ProgramomradeResource getProgramomrade(FagResource fag, DataFetchingEnvironment dfe) {
-        return programomradeService.getProgramomradeResource(
-            Links.get(fag.getProgramomrade()),
-            dfe);
+    public List<ProgramomradeResource> getProgramomrade(FagResource fag, DataFetchingEnvironment dfe) {
+        return fag.getProgramomrade()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> programomradeService.getProgramomradeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public SkoleResource getSkole(FagResource fag, DataFetchingEnvironment dfe) {
-        return skoleService.getSkoleResource(
-            Links.get(fag.getSkole()),
-            dfe);
+    public List<SkoleResource> getSkole(FagResource fag, DataFetchingEnvironment dfe) {
+        return fag.getSkole()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> skoleService.getSkoleResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public UndervisningsgruppeResource getUndervisningsgruppe(FagResource fag, DataFetchingEnvironment dfe) {
-        return undervisningsgruppeService.getUndervisningsgruppeResource(
-            Links.get(fag.getUndervisningsgruppe()),
-            dfe);
+    public List<UndervisningsgruppeResource> getUndervisningsgruppe(FagResource fag, DataFetchingEnvironment dfe) {
+        return fag.getUndervisningsgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public EksamensgruppeResource getEksamensgruppe(FagResource fag, DataFetchingEnvironment dfe) {
-        return eksamensgruppeService.getEksamensgruppeResource(
-            Links.get(fag.getEksamensgruppe()),
-            dfe);
+    public List<EksamensgruppeResource> getEksamensgruppe(FagResource fag, DataFetchingEnvironment dfe) {
+        return fag.getEksamensgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public MedlemskapResource getMedlemskap(FagResource fag, DataFetchingEnvironment dfe) {
-        return medlemskapService.getMedlemskapResource(
-            Links.get(fag.getMedlemskap()),
-            dfe);
+    public List<MedlemskapResource> getMedlemskap(FagResource fag, DataFetchingEnvironment dfe) {
+        return fag.getMedlemskap()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/fag/FagResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/fag/FagResolver.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningFagResolver")
@@ -47,42 +48,47 @@ public class FagResolver implements GraphQLResolver<FagResource> {
 
     public List<ProgramomradeResource> getProgramomrade(FagResource fag, DataFetchingEnvironment dfe) {
         return fag.getProgramomrade()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> programomradeService.getProgramomradeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> programomradeService.getProgramomradeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<SkoleResource> getSkole(FagResource fag, DataFetchingEnvironment dfe) {
         return fag.getSkole()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> skoleService.getSkoleResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> skoleService.getSkoleResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<UndervisningsgruppeResource> getUndervisningsgruppe(FagResource fag, DataFetchingEnvironment dfe) {
         return fag.getUndervisningsgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<EksamensgruppeResource> getEksamensgruppe(FagResource fag, DataFetchingEnvironment dfe) {
         return fag.getEksamensgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<MedlemskapResource> getMedlemskap(FagResource fag, DataFetchingEnvironment dfe) {
         return fag.getMedlemskap()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/fag/FagService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/fag/FagService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.fag;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.timeplan.FagResource;
-import no.fint.model.resource.utdanning.timeplan.FagResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class FagService {
     @Autowired
     private Endpoints endpoints;
 
-    public FagResources getFagResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningTimeplan() + "/fag",
-                    sinceTimeStamp),
-                FagResources.class,
-                dfe);
+    public FagResource getFagResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getFagResource(
+            endpoints.getUtdanningTimeplan() 
+                + "/fag/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public FagResource getFagResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/karakterskala/KarakterskalaQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/karakterskala/KarakterskalaQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.karakterskala;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.kodeverk.KarakterskalaResource;
-import no.fint.model.resource.utdanning.kodeverk.KarakterskalaResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningKarakterskalaQueryResolver")
 public class KarakterskalaQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class KarakterskalaQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private KarakterskalaService service;
 
-    public List<KarakterskalaResource> getKarakterskala(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        KarakterskalaResources resources = service.getKarakterskalaResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public KarakterskalaResource getKarakterskala(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getKarakterskalaResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/karakterskala/KarakterskalaResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/karakterskala/KarakterskalaResolver.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningKarakterskalaResolver")
@@ -27,10 +28,11 @@ public class KarakterskalaResolver implements GraphQLResolver<KarakterskalaResou
 
     public List<KarakterverdiResource> getVerdi(KarakterskalaResource karakterskala, DataFetchingEnvironment dfe) {
         return karakterskala.getVerdi()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> karakterverdiService.getKarakterverdiResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> karakterverdiService.getKarakterverdiResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/karakterskala/KarakterskalaResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/karakterskala/KarakterskalaResolver.java
@@ -4,35 +4,33 @@ package no.fint.graphql.model.utdanning.karakterskala;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.utdanning.karakterverdi.KarakterverdiService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.kodeverk.KarakterskalaResource;
-
-
 import no.fint.model.resource.utdanning.vurdering.KarakterverdiResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningKarakterskalaResolver")
 public class KarakterskalaResolver implements GraphQLResolver<KarakterskalaResource> {
-
 
     @Autowired
     private KarakterverdiService karakterverdiService;
 
 
-    public KarakterverdiResource getVerdi(KarakterskalaResource karakterskala, DataFetchingEnvironment dfe) {
-        return karakterverdiService.getKarakterverdiResource(
-            Links.get(karakterskala.getVerdi()),
-            dfe);
+    public List<KarakterverdiResource> getVerdi(KarakterskalaResource karakterskala, DataFetchingEnvironment dfe) {
+        return karakterskala.getVerdi()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> karakterverdiService.getKarakterverdiResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/karakterskala/KarakterskalaService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/karakterskala/KarakterskalaService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.karakterskala;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.kodeverk.KarakterskalaResource;
-import no.fint.model.resource.utdanning.kodeverk.KarakterskalaResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class KarakterskalaService {
     @Autowired
     private Endpoints endpoints;
 
-    public KarakterskalaResources getKarakterskalaResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningKodeverk() + "/karakterskala",
-                    sinceTimeStamp),
-                KarakterskalaResources.class,
-                dfe);
+    public KarakterskalaResource getKarakterskalaResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getKarakterskalaResource(
+            endpoints.getUtdanningKodeverk() 
+                + "/karakterskala/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public KarakterskalaResource getKarakterskalaResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/karakterverdi/KarakterverdiQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/karakterverdi/KarakterverdiQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.karakterverdi;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.vurdering.KarakterverdiResource;
-import no.fint.model.resource.utdanning.vurdering.KarakterverdiResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningKarakterverdiQueryResolver")
 public class KarakterverdiQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class KarakterverdiQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private KarakterverdiService service;
 
-    public List<KarakterverdiResource> getKarakterverdi(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        KarakterverdiResources resources = service.getKarakterverdiResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public KarakterverdiResource getKarakterverdi(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getKarakterverdiResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/karakterverdi/KarakterverdiResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/karakterverdi/KarakterverdiResolver.java
@@ -4,35 +4,33 @@ package no.fint.graphql.model.utdanning.karakterverdi;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.utdanning.karakterskala.KarakterskalaService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.vurdering.KarakterverdiResource;
-
-
 import no.fint.model.resource.utdanning.kodeverk.KarakterskalaResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningKarakterverdiResolver")
 public class KarakterverdiResolver implements GraphQLResolver<KarakterverdiResource> {
-
 
     @Autowired
     private KarakterskalaService karakterskalaService;
 
 
     public KarakterskalaResource getSkala(KarakterverdiResource karakterverdi, DataFetchingEnvironment dfe) {
-        return karakterskalaService.getKarakterskalaResource(
-            Links.get(karakterverdi.getSkala()),
-            dfe);
+        return karakterverdi.getSkala()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> karakterskalaService.getKarakterskalaResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/karakterverdi/KarakterverdiResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/karakterverdi/KarakterverdiResolver.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningKarakterverdiResolver")
@@ -27,10 +28,11 @@ public class KarakterverdiResolver implements GraphQLResolver<KarakterverdiResou
 
     public KarakterskalaResource getSkala(KarakterverdiResource karakterverdi, DataFetchingEnvironment dfe) {
         return karakterverdi.getSkala()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> karakterskalaService.getKarakterskalaResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> karakterskalaService.getKarakterskalaResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/karakterverdi/KarakterverdiService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/karakterverdi/KarakterverdiService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.karakterverdi;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.vurdering.KarakterverdiResource;
-import no.fint.model.resource.utdanning.vurdering.KarakterverdiResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class KarakterverdiService {
     @Autowired
     private Endpoints endpoints;
 
-    public KarakterverdiResources getKarakterverdiResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningVurdering() + "/karakterverdi",
-                    sinceTimeStamp),
-                KarakterverdiResources.class,
-                dfe);
+    public KarakterverdiResource getKarakterverdiResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getKarakterverdiResource(
+            endpoints.getUtdanningVurdering() 
+                + "/karakterverdi/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public KarakterverdiResource getKarakterverdiResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.kontaktlarergruppe;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.elev.KontaktlarergruppeResource;
-import no.fint.model.resource.utdanning.elev.KontaktlarergruppeResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningKontaktlarergruppeQueryResolver")
 public class KontaktlarergruppeQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class KontaktlarergruppeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private KontaktlarergruppeService service;
 
-    public List<KontaktlarergruppeResource> getKontaktlarergruppe(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        KontaktlarergruppeResources resources = service.getKontaktlarergruppeResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public KontaktlarergruppeResource getKontaktlarergruppe(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getKontaktlarergruppeResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeResolver.java
@@ -4,10 +4,6 @@ package no.fint.graphql.model.utdanning.kontaktlarergruppe;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.utdanning.basisgruppe.BasisgruppeService;
 import no.fint.graphql.model.utdanning.skole.SkoleService;
@@ -16,22 +12,22 @@ import no.fint.graphql.model.utdanning.undervisningsforhold.Undervisningsforhold
 import no.fint.graphql.model.utdanning.medlemskap.MedlemskapService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.elev.KontaktlarergruppeResource;
-
-
 import no.fint.model.resource.utdanning.elev.BasisgruppeResource;
 import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
 import no.fint.model.resource.utdanning.elev.ElevforholdResource;
 import no.fint.model.resource.utdanning.elev.UndervisningsforholdResource;
 import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningKontaktlarergruppeResolver")
 public class KontaktlarergruppeResolver implements GraphQLResolver<KontaktlarergruppeResource> {
-
 
     @Autowired
     private BasisgruppeService basisgruppeService;
@@ -49,34 +45,44 @@ public class KontaktlarergruppeResolver implements GraphQLResolver<Kontaktlarerg
     private MedlemskapService medlemskapService;
 
 
-    public BasisgruppeResource getBasisgruppe(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
-        return basisgruppeService.getBasisgruppeResource(
-            Links.get(kontaktlarergruppe.getBasisgruppe()),
-            dfe);
+    public List<BasisgruppeResource> getBasisgruppe(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
+        return kontaktlarergruppe.getBasisgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
     public SkoleResource getSkole(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
-        return skoleService.getSkoleResource(
-            Links.get(kontaktlarergruppe.getSkole()),
-            dfe);
+        return kontaktlarergruppe.getSkole()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> skoleService.getSkoleResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public ElevforholdResource getElevforhold(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
-        return elevforholdService.getElevforholdResource(
-            Links.get(kontaktlarergruppe.getElevforhold()),
-            dfe);
+    public List<ElevforholdResource> getElevforhold(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
+        return kontaktlarergruppe.getElevforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> elevforholdService.getElevforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public UndervisningsforholdResource getUndervisningsforhold(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
-        return undervisningsforholdService.getUndervisningsforholdResource(
-            Links.get(kontaktlarergruppe.getUndervisningsforhold()),
-            dfe);
+    public List<UndervisningsforholdResource> getUndervisningsforhold(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
+        return kontaktlarergruppe.getUndervisningsforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public MedlemskapResource getMedlemskap(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
-        return medlemskapService.getMedlemskapResource(
-            Links.get(kontaktlarergruppe.getMedlemskap()),
-            dfe);
+    public List<MedlemskapResource> getMedlemskap(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
+        return kontaktlarergruppe.getMedlemskap()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeResolver.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningKontaktlarergruppeResolver")
@@ -47,42 +48,47 @@ public class KontaktlarergruppeResolver implements GraphQLResolver<Kontaktlarerg
 
     public List<BasisgruppeResource> getBasisgruppe(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
         return kontaktlarergruppe.getBasisgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public SkoleResource getSkole(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
         return kontaktlarergruppe.getSkole()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> skoleService.getSkoleResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> skoleService.getSkoleResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<ElevforholdResource> getElevforhold(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
         return kontaktlarergruppe.getElevforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> elevforholdService.getElevforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> elevforholdService.getElevforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<UndervisningsforholdResource> getUndervisningsforhold(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
         return kontaktlarergruppe.getUndervisningsforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<MedlemskapResource> getMedlemskap(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
         return kontaktlarergruppe.getMedlemskap()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.kontaktlarergruppe;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.elev.KontaktlarergruppeResource;
-import no.fint.model.resource.utdanning.elev.KontaktlarergruppeResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class KontaktlarergruppeService {
     @Autowired
     private Endpoints endpoints;
 
-    public KontaktlarergruppeResources getKontaktlarergruppeResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningElev() + "/kontaktlarergruppe",
-                    sinceTimeStamp),
-                KontaktlarergruppeResources.class,
-                dfe);
+    public KontaktlarergruppeResource getKontaktlarergruppeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getKontaktlarergruppeResource(
+            endpoints.getUtdanningElev() 
+                + "/kontaktlarergruppe/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public KontaktlarergruppeResource getKontaktlarergruppeResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/medlemskap/MedlemskapQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/medlemskap/MedlemskapQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.medlemskap;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.elev.MedlemskapResource;
-import no.fint.model.resource.utdanning.elev.MedlemskapResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningMedlemskapQueryResolver")
 public class MedlemskapQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class MedlemskapQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private MedlemskapService service;
 
-    public List<MedlemskapResource> getMedlemskap(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        MedlemskapResources resources = service.getMedlemskapResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public MedlemskapResource getMedlemskap(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getMedlemskapResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/medlemskap/MedlemskapResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/medlemskap/MedlemskapResolver.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningMedlemskapResolver")
@@ -27,18 +28,20 @@ public class MedlemskapResolver implements GraphQLResolver<MedlemskapResource> {
 
     public List<VurderingResource> getFortlopendeVurdering(MedlemskapResource medlemskap, DataFetchingEnvironment dfe) {
         return medlemskap.getFortlopendeVurdering()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> vurderingService.getVurderingResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> vurderingService.getVurderingResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public VurderingResource getEndeligVurdering(MedlemskapResource medlemskap, DataFetchingEnvironment dfe) {
         return medlemskap.getEndeligVurdering()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> vurderingService.getVurderingResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> vurderingService.getVurderingResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/medlemskap/MedlemskapResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/medlemskap/MedlemskapResolver.java
@@ -4,41 +4,41 @@ package no.fint.graphql.model.utdanning.medlemskap;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.utdanning.vurdering.VurderingService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.elev.MedlemskapResource;
-
-
 import no.fint.model.resource.utdanning.vurdering.VurderingResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningMedlemskapResolver")
 public class MedlemskapResolver implements GraphQLResolver<MedlemskapResource> {
-
 
     @Autowired
     private VurderingService vurderingService;
 
 
-    public VurderingResource getFortlopendeVurdering(MedlemskapResource medlemskap, DataFetchingEnvironment dfe) {
-        return vurderingService.getVurderingResource(
-            Links.get(medlemskap.getFortlopendeVurdering()),
-            dfe);
+    public List<VurderingResource> getFortlopendeVurdering(MedlemskapResource medlemskap, DataFetchingEnvironment dfe) {
+        return medlemskap.getFortlopendeVurdering()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> vurderingService.getVurderingResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
     public VurderingResource getEndeligVurdering(MedlemskapResource medlemskap, DataFetchingEnvironment dfe) {
-        return vurderingService.getVurderingResource(
-            Links.get(medlemskap.getEndeligVurdering()),
-            dfe);
+        return medlemskap.getEndeligVurdering()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> vurderingService.getVurderingResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/medlemskap/MedlemskapService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/medlemskap/MedlemskapService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.medlemskap;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.elev.MedlemskapResource;
-import no.fint.model.resource.utdanning.elev.MedlemskapResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class MedlemskapService {
     @Autowired
     private Endpoints endpoints;
 
-    public MedlemskapResources getMedlemskapResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningElev() + "/medlemskap",
-                    sinceTimeStamp),
-                MedlemskapResources.class,
-                dfe);
+    public MedlemskapResource getMedlemskapResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getMedlemskapResource(
+            endpoints.getUtdanningElev() 
+                + "/medlemskap/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public MedlemskapResource getMedlemskapResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.programomrade;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.utdanningsprogram.ProgramomradeResource;
-import no.fint.model.resource.utdanning.utdanningsprogram.ProgramomradeResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningProgramomradeQueryResolver")
 public class ProgramomradeQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class ProgramomradeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ProgramomradeService service;
 
-    public List<ProgramomradeResource> getProgramomrade(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        ProgramomradeResources resources = service.getProgramomradeResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public ProgramomradeResource getProgramomrade(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getProgramomradeResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeResolver.java
@@ -4,10 +4,6 @@ package no.fint.graphql.model.utdanning.programomrade;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.utdanning.utdanningsprogram.UtdanningsprogramService;
 import no.fint.graphql.model.utdanning.fag.FagService;
@@ -15,21 +11,21 @@ import no.fint.graphql.model.utdanning.arstrinn.ArstrinnService;
 import no.fint.graphql.model.utdanning.medlemskap.MedlemskapService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.utdanningsprogram.ProgramomradeResource;
-
-
 import no.fint.model.resource.utdanning.utdanningsprogram.UtdanningsprogramResource;
 import no.fint.model.resource.utdanning.timeplan.FagResource;
 import no.fint.model.resource.utdanning.utdanningsprogram.ArstrinnResource;
 import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningProgramomradeResolver")
 public class ProgramomradeResolver implements GraphQLResolver<ProgramomradeResource> {
-
 
     @Autowired
     private UtdanningsprogramService utdanningsprogramService;
@@ -45,27 +41,35 @@ public class ProgramomradeResolver implements GraphQLResolver<ProgramomradeResou
 
 
     public UtdanningsprogramResource getUtdanningsprogram(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
-        return utdanningsprogramService.getUtdanningsprogramResource(
-            Links.get(programomrade.getUtdanningsprogram()),
-            dfe);
+        return programomrade.getUtdanningsprogram()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> utdanningsprogramService.getUtdanningsprogramResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public FagResource getFag(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
-        return fagService.getFagResource(
-            Links.get(programomrade.getFag()),
-            dfe);
+    public List<FagResource> getFag(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
+        return programomrade.getFag()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> fagService.getFagResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public ArstrinnResource getTrinn(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
-        return arstrinnService.getArstrinnResource(
-            Links.get(programomrade.getTrinn()),
-            dfe);
+    public List<ArstrinnResource> getTrinn(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
+        return programomrade.getTrinn()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> arstrinnService.getArstrinnResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public MedlemskapResource getMedlemskap(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
-        return medlemskapService.getMedlemskapResource(
-            Links.get(programomrade.getMedlemskap()),
-            dfe);
+    public List<MedlemskapResource> getMedlemskap(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
+        return programomrade.getMedlemskap()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeResolver.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningProgramomradeResolver")
@@ -42,34 +43,38 @@ public class ProgramomradeResolver implements GraphQLResolver<ProgramomradeResou
 
     public UtdanningsprogramResource getUtdanningsprogram(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
         return programomrade.getUtdanningsprogram()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> utdanningsprogramService.getUtdanningsprogramResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> utdanningsprogramService.getUtdanningsprogramResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<FagResource> getFag(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
         return programomrade.getFag()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> fagService.getFagResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fagService.getFagResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<ArstrinnResource> getTrinn(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
         return programomrade.getTrinn()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> arstrinnService.getArstrinnResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> arstrinnService.getArstrinnResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<MedlemskapResource> getMedlemskap(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
         return programomrade.getMedlemskap()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.programomrade;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.utdanningsprogram.ProgramomradeResource;
-import no.fint.model.resource.utdanning.utdanningsprogram.ProgramomradeResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class ProgramomradeService {
     @Autowired
     private Endpoints endpoints;
 
-    public ProgramomradeResources getProgramomradeResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningUtdanningsprogram() + "/programomrade",
-                    sinceTimeStamp),
-                ProgramomradeResources.class,
-                dfe);
+    public ProgramomradeResource getProgramomradeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getProgramomradeResource(
+            endpoints.getUtdanningUtdanningsprogram() 
+                + "/programomrade/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public ProgramomradeResource getProgramomradeResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/rom/RomQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/rom/RomQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.rom;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.timeplan.RomResource;
-import no.fint.model.resource.utdanning.timeplan.RomResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningRomQueryResolver")
 public class RomQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class RomQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private RomService service;
 
-    public List<RomResource> getRom(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        RomResources resources = service.getRomResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public RomResource getRom(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getRomResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/rom/RomResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/rom/RomResolver.java
@@ -4,35 +4,33 @@ package no.fint.graphql.model.utdanning.rom;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.utdanning.time.TimeService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.timeplan.RomResource;
-
-
 import no.fint.model.resource.utdanning.timeplan.TimeResource;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningRomResolver")
 public class RomResolver implements GraphQLResolver<RomResource> {
-
 
     @Autowired
     private TimeService timeService;
 
 
-    public TimeResource getTime(RomResource rom, DataFetchingEnvironment dfe) {
-        return timeService.getTimeResource(
-            Links.get(rom.getTime()),
-            dfe);
+    public List<TimeResource> getTime(RomResource rom, DataFetchingEnvironment dfe) {
+        return rom.getTime()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> timeService.getTimeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/rom/RomResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/rom/RomResolver.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningRomResolver")
@@ -27,10 +28,11 @@ public class RomResolver implements GraphQLResolver<RomResource> {
 
     public List<TimeResource> getTime(RomResource rom, DataFetchingEnvironment dfe) {
         return rom.getTime()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> timeService.getTimeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> timeService.getTimeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/rom/RomService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/rom/RomService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.rom;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.timeplan.RomResource;
-import no.fint.model.resource.utdanning.timeplan.RomResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class RomService {
     @Autowired
     private Endpoints endpoints;
 
-    public RomResources getRomResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningTimeplan() + "/rom",
-                    sinceTimeStamp),
-                RomResources.class,
-                dfe);
+    public RomResource getRomResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getRomResource(
+            endpoints.getUtdanningTimeplan() 
+                + "/rom/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public RomResource getRomResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.skole;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
-import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningSkoleQueryResolver")
 public class SkoleQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,20 @@ public class SkoleQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private SkoleService service;
 
-    public List<SkoleResource> getSkole(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        SkoleResources resources = service.getSkoleResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public SkoleResource getSkole(
+            String skolenummer,
+            String systemId,
+            String organisasjonsnummer,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(skolenummer)) {
+            return service.getSkoleResourceById("skolenummer", skolenummer, dfe);
+        }
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getSkoleResourceById("systemid", systemId, dfe);
+        }
+        if (StringUtils.isNotEmpty(organisasjonsnummer)) {
+            return service.getSkoleResourceById("organisasjonsnummer", organisasjonsnummer, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleResolver.java
@@ -36,6 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningSkoleResolver")
@@ -77,90 +78,101 @@ public class SkoleResolver implements GraphQLResolver<SkoleResource> {
 
     public OrganisasjonselementResource getOrganisasjon(SkoleResource skole, DataFetchingEnvironment dfe) {
         return skole.getOrganisasjon()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<FagResource> getFag(SkoleResource skole, DataFetchingEnvironment dfe) {
         return skole.getFag()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> fagService.getFagResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fagService.getFagResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public SkoleeiertypeResource getSkoleeierType(SkoleResource skole, DataFetchingEnvironment dfe) {
         return skole.getSkoleeierType()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> skoleeiertypeService.getSkoleeiertypeResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> skoleeiertypeService.getSkoleeiertypeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<BasisgruppeResource> getBasisgruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
         return skole.getBasisgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<ElevforholdResource> getElevforhold(SkoleResource skole, DataFetchingEnvironment dfe) {
         return skole.getElevforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> elevforholdService.getElevforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> elevforholdService.getElevforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<KontaktlarergruppeResource> getKontaktlarergruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
         return skole.getKontaktlarergruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<SkoleressursResource> getSkoleressurs(SkoleResource skole, DataFetchingEnvironment dfe) {
         return skole.getSkoleressurs()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> skoleressursService.getSkoleressursResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> skoleressursService.getSkoleressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<UndervisningsforholdResource> getUndervisningsforhold(SkoleResource skole, DataFetchingEnvironment dfe) {
         return skole.getUndervisningsforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<UndervisningsgruppeResource> getUndervisningsgruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
         return skole.getUndervisningsgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<EksamensgruppeResource> getEksamensgruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
         return skole.getEksamensgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<UtdanningsprogramResource> getUtdanningsprogram(SkoleResource skole, DataFetchingEnvironment dfe) {
         return skole.getUtdanningsprogram()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> utdanningsprogramService.getUtdanningsprogramResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> utdanningsprogramService.getUtdanningsprogramResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleResolver.java
@@ -4,10 +4,6 @@ package no.fint.graphql.model.utdanning.skole;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.organisasjonselement.OrganisasjonselementService;
 import no.fint.graphql.model.utdanning.fag.FagService;
@@ -22,9 +18,8 @@ import no.fint.graphql.model.utdanning.eksamensgruppe.EksamensgruppeService;
 import no.fint.graphql.model.utdanning.utdanningsprogram.UtdanningsprogramService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
-
-
 import no.fint.model.resource.administrasjon.organisasjon.OrganisasjonselementResource;
 import no.fint.model.resource.utdanning.timeplan.FagResource;
 import no.fint.model.resource.utdanning.kodeverk.SkoleeiertypeResource;
@@ -37,13 +32,14 @@ import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResource;
 import no.fint.model.resource.utdanning.vurdering.EksamensgruppeResource;
 import no.fint.model.resource.utdanning.utdanningsprogram.UtdanningsprogramResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningSkoleResolver")
 public class SkoleResolver implements GraphQLResolver<SkoleResource> {
-
 
     @Autowired
     private OrganisasjonselementService organisasjonselementService;
@@ -80,69 +76,91 @@ public class SkoleResolver implements GraphQLResolver<SkoleResource> {
 
 
     public OrganisasjonselementResource getOrganisasjon(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return organisasjonselementService.getOrganisasjonselementResource(
-            Links.get(skole.getOrganisasjon()),
-            dfe);
+        return skole.getOrganisasjon()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public FagResource getFag(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return fagService.getFagResource(
-            Links.get(skole.getFag()),
-            dfe);
+    public List<FagResource> getFag(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return skole.getFag()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> fagService.getFagResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
     public SkoleeiertypeResource getSkoleeierType(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return skoleeiertypeService.getSkoleeiertypeResource(
-            Links.get(skole.getSkoleeierType()),
-            dfe);
+        return skole.getSkoleeierType()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> skoleeiertypeService.getSkoleeiertypeResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public BasisgruppeResource getBasisgruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return basisgruppeService.getBasisgruppeResource(
-            Links.get(skole.getBasisgruppe()),
-            dfe);
+    public List<BasisgruppeResource> getBasisgruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return skole.getBasisgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public ElevforholdResource getElevforhold(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return elevforholdService.getElevforholdResource(
-            Links.get(skole.getElevforhold()),
-            dfe);
+    public List<ElevforholdResource> getElevforhold(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return skole.getElevforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> elevforholdService.getElevforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public KontaktlarergruppeResource getKontaktlarergruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return kontaktlarergruppeService.getKontaktlarergruppeResource(
-            Links.get(skole.getKontaktlarergruppe()),
-            dfe);
+    public List<KontaktlarergruppeResource> getKontaktlarergruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return skole.getKontaktlarergruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public SkoleressursResource getSkoleressurs(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return skoleressursService.getSkoleressursResource(
-            Links.get(skole.getSkoleressurs()),
-            dfe);
+    public List<SkoleressursResource> getSkoleressurs(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return skole.getSkoleressurs()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> skoleressursService.getSkoleressursResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public UndervisningsforholdResource getUndervisningsforhold(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return undervisningsforholdService.getUndervisningsforholdResource(
-            Links.get(skole.getUndervisningsforhold()),
-            dfe);
+    public List<UndervisningsforholdResource> getUndervisningsforhold(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return skole.getUndervisningsforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public UndervisningsgruppeResource getUndervisningsgruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return undervisningsgruppeService.getUndervisningsgruppeResource(
-            Links.get(skole.getUndervisningsgruppe()),
-            dfe);
+    public List<UndervisningsgruppeResource> getUndervisningsgruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return skole.getUndervisningsgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public EksamensgruppeResource getEksamensgruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return eksamensgruppeService.getEksamensgruppeResource(
-            Links.get(skole.getEksamensgruppe()),
-            dfe);
+    public List<EksamensgruppeResource> getEksamensgruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return skole.getEksamensgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public UtdanningsprogramResource getUtdanningsprogram(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return utdanningsprogramService.getUtdanningsprogramResource(
-            Links.get(skole.getUtdanningsprogram()),
-            dfe);
+    public List<UtdanningsprogramResource> getUtdanningsprogram(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return skole.getUtdanningsprogram()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> utdanningsprogramService.getUtdanningsprogramResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.skole;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
-import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class SkoleService {
     @Autowired
     private Endpoints endpoints;
 
-    public SkoleResources getSkoleResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningUtdanningsprogram() + "/skole",
-                    sinceTimeStamp),
-                SkoleResources.class,
-                dfe);
+    public SkoleResource getSkoleResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getSkoleResource(
+            endpoints.getUtdanningUtdanningsprogram() 
+                + "/skole/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public SkoleResource getSkoleResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/skoleeiertype/SkoleeiertypeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skoleeiertype/SkoleeiertypeQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.skoleeiertype;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.kodeverk.SkoleeiertypeResource;
-import no.fint.model.resource.utdanning.kodeverk.SkoleeiertypeResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningSkoleeiertypeQueryResolver")
 public class SkoleeiertypeQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class SkoleeiertypeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private SkoleeiertypeService service;
 
-    public List<SkoleeiertypeResource> getSkoleeiertype(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        SkoleeiertypeResources resources = service.getSkoleeiertypeResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public SkoleeiertypeResource getSkoleeiertype(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getSkoleeiertypeResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/skoleeiertype/SkoleeiertypeService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skoleeiertype/SkoleeiertypeService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.skoleeiertype;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.kodeverk.SkoleeiertypeResource;
-import no.fint.model.resource.utdanning.kodeverk.SkoleeiertypeResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class SkoleeiertypeService {
     @Autowired
     private Endpoints endpoints;
 
-    public SkoleeiertypeResources getSkoleeiertypeResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningKodeverk() + "/skoleeiertype",
-                    sinceTimeStamp),
-                SkoleeiertypeResources.class,
-                dfe);
+    public SkoleeiertypeResource getSkoleeiertypeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getSkoleeiertypeResource(
+            endpoints.getUtdanningKodeverk() 
+                + "/skoleeiertype/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public SkoleeiertypeResource getSkoleeiertypeResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/skoleressurs/SkoleressursQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skoleressurs/SkoleressursQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.skoleressurs;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.elev.SkoleressursResource;
-import no.fint.model.resource.utdanning.elev.SkoleressursResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningSkoleressursQueryResolver")
 public class SkoleressursQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,16 @@ public class SkoleressursQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private SkoleressursService service;
 
-    public List<SkoleressursResource> getSkoleressurs(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        SkoleressursResources resources = service.getSkoleressursResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public SkoleressursResource getSkoleressurs(
+            String feidenavn,
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(feidenavn)) {
+            return service.getSkoleressursResourceById("feidenavn", feidenavn, dfe);
+        }
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getSkoleressursResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/skoleressurs/SkoleressursResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skoleressurs/SkoleressursResolver.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningSkoleressursResolver")
@@ -37,26 +38,29 @@ public class SkoleressursResolver implements GraphQLResolver<SkoleressursResourc
 
     public PersonalressursResource getPersonalressurs(SkoleressursResource skoleressurs, DataFetchingEnvironment dfe) {
         return skoleressurs.getPersonalressurs()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<UndervisningsforholdResource> getUndervisningsforhold(SkoleressursResource skoleressurs, DataFetchingEnvironment dfe) {
         return skoleressurs.getUndervisningsforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public SkoleResource getSkole(SkoleressursResource skoleressurs, DataFetchingEnvironment dfe) {
         return skoleressurs.getSkole()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> skoleService.getSkoleResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> skoleService.getSkoleResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/skoleressurs/SkoleressursResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skoleressurs/SkoleressursResolver.java
@@ -4,30 +4,26 @@ package no.fint.graphql.model.utdanning.skoleressurs;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.personalressurs.PersonalressursService;
 import no.fint.graphql.model.utdanning.undervisningsforhold.UndervisningsforholdService;
 import no.fint.graphql.model.utdanning.skole.SkoleService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.elev.SkoleressursResource;
-
-
 import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
 import no.fint.model.resource.utdanning.elev.UndervisningsforholdResource;
 import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningSkoleressursResolver")
 public class SkoleressursResolver implements GraphQLResolver<SkoleressursResource> {
-
 
     @Autowired
     private PersonalressursService personalressursService;
@@ -40,21 +36,27 @@ public class SkoleressursResolver implements GraphQLResolver<SkoleressursResourc
 
 
     public PersonalressursResource getPersonalressurs(SkoleressursResource skoleressurs, DataFetchingEnvironment dfe) {
-        return personalressursService.getPersonalressursResource(
-            Links.get(skoleressurs.getPersonalressurs()),
-            dfe);
+        return skoleressurs.getPersonalressurs()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> personalressursService.getPersonalressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public UndervisningsforholdResource getUndervisningsforhold(SkoleressursResource skoleressurs, DataFetchingEnvironment dfe) {
-        return undervisningsforholdService.getUndervisningsforholdResource(
-            Links.get(skoleressurs.getUndervisningsforhold()),
-            dfe);
+    public List<UndervisningsforholdResource> getUndervisningsforhold(SkoleressursResource skoleressurs, DataFetchingEnvironment dfe) {
+        return skoleressurs.getUndervisningsforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
     public SkoleResource getSkole(SkoleressursResource skoleressurs, DataFetchingEnvironment dfe) {
-        return skoleService.getSkoleResource(
-            Links.get(skoleressurs.getSkole()),
-            dfe);
+        return skoleressurs.getSkole()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> skoleService.getSkoleResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/skoleressurs/SkoleressursService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skoleressurs/SkoleressursService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.skoleressurs;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.elev.SkoleressursResource;
-import no.fint.model.resource.utdanning.elev.SkoleressursResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class SkoleressursService {
     @Autowired
     private Endpoints endpoints;
 
-    public SkoleressursResources getSkoleressursResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningElev() + "/skoleressurs",
-                    sinceTimeStamp),
-                SkoleressursResources.class,
-                dfe);
+    public SkoleressursResource getSkoleressursResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getSkoleressursResource(
+            endpoints.getUtdanningElev() 
+                + "/skoleressurs/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public SkoleressursResource getSkoleressursResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/time/TimeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/time/TimeQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.time;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.timeplan.TimeResource;
-import no.fint.model.resource.utdanning.timeplan.TimeResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningTimeQueryResolver")
 public class TimeQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class TimeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private TimeService service;
 
-    public List<TimeResource> getTime(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        TimeResources resources = service.getTimeResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public TimeResource getTime(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getTimeResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/time/TimeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/time/TimeResolver.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningTimeResolver")
@@ -37,26 +38,29 @@ public class TimeResolver implements GraphQLResolver<TimeResource> {
 
     public List<UndervisningsgruppeResource> getUndervisningsgruppe(TimeResource time, DataFetchingEnvironment dfe) {
         return time.getUndervisningsgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<UndervisningsforholdResource> getUndervisningsforhold(TimeResource time, DataFetchingEnvironment dfe) {
         return time.getUndervisningsforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<RomResource> getRom(TimeResource time, DataFetchingEnvironment dfe) {
         return time.getRom()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> romService.getRomResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> romService.getRomResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/time/TimeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/time/TimeResolver.java
@@ -4,30 +4,26 @@ package no.fint.graphql.model.utdanning.time;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.utdanning.undervisningsgruppe.UndervisningsgruppeService;
 import no.fint.graphql.model.utdanning.undervisningsforhold.UndervisningsforholdService;
 import no.fint.graphql.model.utdanning.rom.RomService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.timeplan.TimeResource;
-
-
 import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResource;
 import no.fint.model.resource.utdanning.elev.UndervisningsforholdResource;
 import no.fint.model.resource.utdanning.timeplan.RomResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningTimeResolver")
 public class TimeResolver implements GraphQLResolver<TimeResource> {
-
 
     @Autowired
     private UndervisningsgruppeService undervisningsgruppeService;
@@ -39,22 +35,28 @@ public class TimeResolver implements GraphQLResolver<TimeResource> {
     private RomService romService;
 
 
-    public UndervisningsgruppeResource getUndervisningsgruppe(TimeResource time, DataFetchingEnvironment dfe) {
-        return undervisningsgruppeService.getUndervisningsgruppeResource(
-            Links.get(time.getUndervisningsgruppe()),
-            dfe);
+    public List<UndervisningsgruppeResource> getUndervisningsgruppe(TimeResource time, DataFetchingEnvironment dfe) {
+        return time.getUndervisningsgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public UndervisningsforholdResource getUndervisningsforhold(TimeResource time, DataFetchingEnvironment dfe) {
-        return undervisningsforholdService.getUndervisningsforholdResource(
-            Links.get(time.getUndervisningsforhold()),
-            dfe);
+    public List<UndervisningsforholdResource> getUndervisningsforhold(TimeResource time, DataFetchingEnvironment dfe) {
+        return time.getUndervisningsforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public RomResource getRom(TimeResource time, DataFetchingEnvironment dfe) {
-        return romService.getRomResource(
-            Links.get(time.getRom()),
-            dfe);
+    public List<RomResource> getRom(TimeResource time, DataFetchingEnvironment dfe) {
+        return time.getRom()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> romService.getRomResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/time/TimeService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/time/TimeService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.time;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.timeplan.TimeResource;
-import no.fint.model.resource.utdanning.timeplan.TimeResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class TimeService {
     @Autowired
     private Endpoints endpoints;
 
-    public TimeResources getTimeResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningTimeplan() + "/time",
-                    sinceTimeStamp),
-                TimeResources.class,
-                dfe);
+    public TimeResource getTimeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getTimeResource(
+            endpoints.getUtdanningTimeplan() 
+                + "/time/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public TimeResource getTimeResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.undervisningsforhold;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.elev.UndervisningsforholdResource;
-import no.fint.model.resource.utdanning.elev.UndervisningsforholdResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningUndervisningsforholdQueryResolver")
 public class UndervisningsforholdQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class UndervisningsforholdQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private UndervisningsforholdService service;
 
-    public List<UndervisningsforholdResource> getUndervisningsforhold(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        UndervisningsforholdResources resources = service.getUndervisningsforholdResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public UndervisningsforholdResource getUndervisningsforhold(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getUndervisningsforholdResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdResolver.java
@@ -4,10 +4,6 @@ package no.fint.graphql.model.utdanning.undervisningsforhold;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.administrasjon.arbeidsforhold.ArbeidsforholdService;
 import no.fint.graphql.model.utdanning.basisgruppe.BasisgruppeService;
@@ -20,9 +16,8 @@ import no.fint.graphql.model.utdanning.skoleressurs.SkoleressursService;
 import no.fint.graphql.model.utdanning.medlemskap.MedlemskapService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.elev.UndervisningsforholdResource;
-
-
 import no.fint.model.resource.administrasjon.personal.ArbeidsforholdResource;
 import no.fint.model.resource.utdanning.elev.BasisgruppeResource;
 import no.fint.model.resource.utdanning.elev.KontaktlarergruppeResource;
@@ -33,13 +28,14 @@ import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
 import no.fint.model.resource.utdanning.elev.SkoleressursResource;
 import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningUndervisningsforholdResolver")
 public class UndervisningsforholdResolver implements GraphQLResolver<UndervisningsforholdResource> {
-
 
     @Autowired
     private ArbeidsforholdService arbeidsforholdService;
@@ -70,57 +66,75 @@ public class UndervisningsforholdResolver implements GraphQLResolver<Undervisnin
 
 
     public ArbeidsforholdResource getArbeidsforhold(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return arbeidsforholdService.getArbeidsforholdResource(
-            Links.get(undervisningsforhold.getArbeidsforhold()),
-            dfe);
+        return undervisningsforhold.getArbeidsforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public BasisgruppeResource getBasisgruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return basisgruppeService.getBasisgruppeResource(
-            Links.get(undervisningsforhold.getBasisgruppe()),
-            dfe);
+    public List<BasisgruppeResource> getBasisgruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
+        return undervisningsforhold.getBasisgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public KontaktlarergruppeResource getKontaktlarergruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return kontaktlarergruppeService.getKontaktlarergruppeResource(
-            Links.get(undervisningsforhold.getKontaktlarergruppe()),
-            dfe);
+    public List<KontaktlarergruppeResource> getKontaktlarergruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
+        return undervisningsforhold.getKontaktlarergruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public UndervisningsgruppeResource getUndervisningsgruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return undervisningsgruppeService.getUndervisningsgruppeResource(
-            Links.get(undervisningsforhold.getUndervisningsgruppe()),
-            dfe);
+    public List<UndervisningsgruppeResource> getUndervisningsgruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
+        return undervisningsforhold.getUndervisningsgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public EksamensgruppeResource getEksamensgruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return eksamensgruppeService.getEksamensgruppeResource(
-            Links.get(undervisningsforhold.getEksamensgruppe()),
-            dfe);
+    public List<EksamensgruppeResource> getEksamensgruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
+        return undervisningsforhold.getEksamensgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public TimeResource getTime(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return timeService.getTimeResource(
-            Links.get(undervisningsforhold.getTime()),
-            dfe);
+    public List<TimeResource> getTime(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
+        return undervisningsforhold.getTime()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> timeService.getTimeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
     public SkoleResource getSkole(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return skoleService.getSkoleResource(
-            Links.get(undervisningsforhold.getSkole()),
-            dfe);
+        return undervisningsforhold.getSkole()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> skoleService.getSkoleResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public SkoleressursResource getSkoleressurs(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return skoleressursService.getSkoleressursResource(
-            Links.get(undervisningsforhold.getSkoleressurs()),
-            dfe);
+        return undervisningsforhold.getSkoleressurs()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> skoleressursService.getSkoleressursResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public MedlemskapResource getMedlemskap(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return medlemskapService.getMedlemskapResource(
-            Links.get(undervisningsforhold.getMedlemskap()),
-            dfe);
+    public List<MedlemskapResource> getMedlemskap(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
+        return undervisningsforhold.getMedlemskap()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdResolver.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningUndervisningsforholdResolver")
@@ -67,74 +68,83 @@ public class UndervisningsforholdResolver implements GraphQLResolver<Undervisnin
 
     public ArbeidsforholdResource getArbeidsforhold(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
         return undervisningsforhold.getArbeidsforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<BasisgruppeResource> getBasisgruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
         return undervisningsforhold.getBasisgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<KontaktlarergruppeResource> getKontaktlarergruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
         return undervisningsforhold.getKontaktlarergruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<UndervisningsgruppeResource> getUndervisningsgruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
         return undervisningsforhold.getUndervisningsgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<EksamensgruppeResource> getEksamensgruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
         return undervisningsforhold.getEksamensgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<TimeResource> getTime(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
         return undervisningsforhold.getTime()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> timeService.getTimeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> timeService.getTimeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public SkoleResource getSkole(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
         return undervisningsforhold.getSkole()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> skoleService.getSkoleResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> skoleService.getSkoleResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public SkoleressursResource getSkoleressurs(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
         return undervisningsforhold.getSkoleressurs()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> skoleressursService.getSkoleressursResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> skoleressursService.getSkoleressursResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<MedlemskapResource> getMedlemskap(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
         return undervisningsforhold.getMedlemskap()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.undervisningsforhold;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.elev.UndervisningsforholdResource;
-import no.fint.model.resource.utdanning.elev.UndervisningsforholdResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class UndervisningsforholdService {
     @Autowired
     private Endpoints endpoints;
 
-    public UndervisningsforholdResources getUndervisningsforholdResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningElev() + "/undervisningsforhold",
-                    sinceTimeStamp),
-                UndervisningsforholdResources.class,
-                dfe);
+    public UndervisningsforholdResource getUndervisningsforholdResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getUndervisningsforholdResource(
+            endpoints.getUtdanningElev() 
+                + "/undervisningsforhold/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public UndervisningsforholdResource getUndervisningsforholdResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.undervisningsgruppe;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResource;
-import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningUndervisningsgruppeQueryResolver")
 public class UndervisningsgruppeQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class UndervisningsgruppeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private UndervisningsgruppeService service;
 
-    public List<UndervisningsgruppeResource> getUndervisningsgruppe(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        UndervisningsgruppeResources resources = service.getUndervisningsgruppeResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public UndervisningsgruppeResource getUndervisningsgruppe(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getUndervisningsgruppeResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeResolver.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningUndervisningsgruppeResolver")
@@ -52,50 +53,56 @@ public class UndervisningsgruppeResolver implements GraphQLResolver<Undervisning
 
     public List<FagResource> getFag(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
         return undervisningsgruppe.getFag()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> fagService.getFagResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fagService.getFagResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public SkoleResource getSkole(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
         return undervisningsgruppe.getSkole()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> skoleService.getSkoleResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> skoleService.getSkoleResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public List<ElevforholdResource> getElevforhold(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
         return undervisningsgruppe.getElevforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> elevforholdService.getElevforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> elevforholdService.getElevforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<UndervisningsforholdResource> getUndervisningsforhold(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
         return undervisningsgruppe.getUndervisningsforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<TimeResource> getTime(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
         return undervisningsgruppe.getTime()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> timeService.getTimeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> timeService.getTimeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<MedlemskapResource> getMedlemskap(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
         return undervisningsgruppe.getMedlemskap()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeResolver.java
@@ -4,10 +4,6 @@ package no.fint.graphql.model.utdanning.undervisningsgruppe;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.utdanning.fag.FagService;
 import no.fint.graphql.model.utdanning.skole.SkoleService;
@@ -17,9 +13,8 @@ import no.fint.graphql.model.utdanning.time.TimeService;
 import no.fint.graphql.model.utdanning.medlemskap.MedlemskapService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResource;
-
-
 import no.fint.model.resource.utdanning.timeplan.FagResource;
 import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
 import no.fint.model.resource.utdanning.elev.ElevforholdResource;
@@ -27,13 +22,14 @@ import no.fint.model.resource.utdanning.elev.UndervisningsforholdResource;
 import no.fint.model.resource.utdanning.timeplan.TimeResource;
 import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningUndervisningsgruppeResolver")
 public class UndervisningsgruppeResolver implements GraphQLResolver<UndervisningsgruppeResource> {
-
 
     @Autowired
     private FagService fagService;
@@ -54,40 +50,52 @@ public class UndervisningsgruppeResolver implements GraphQLResolver<Undervisning
     private MedlemskapService medlemskapService;
 
 
-    public FagResource getFag(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
-        return fagService.getFagResource(
-            Links.get(undervisningsgruppe.getFag()),
-            dfe);
+    public List<FagResource> getFag(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
+        return undervisningsgruppe.getFag()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> fagService.getFagResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
     public SkoleResource getSkole(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
-        return skoleService.getSkoleResource(
-            Links.get(undervisningsgruppe.getSkole()),
-            dfe);
+        return undervisningsgruppe.getSkole()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> skoleService.getSkoleResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
-    public ElevforholdResource getElevforhold(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
-        return elevforholdService.getElevforholdResource(
-            Links.get(undervisningsgruppe.getElevforhold()),
-            dfe);
+    public List<ElevforholdResource> getElevforhold(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
+        return undervisningsgruppe.getElevforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> elevforholdService.getElevforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public UndervisningsforholdResource getUndervisningsforhold(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
-        return undervisningsforholdService.getUndervisningsforholdResource(
-            Links.get(undervisningsgruppe.getUndervisningsforhold()),
-            dfe);
+    public List<UndervisningsforholdResource> getUndervisningsforhold(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
+        return undervisningsgruppe.getUndervisningsforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public TimeResource getTime(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
-        return timeService.getTimeResource(
-            Links.get(undervisningsgruppe.getTime()),
-            dfe);
+    public List<TimeResource> getTime(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
+        return undervisningsgruppe.getTime()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> timeService.getTimeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public MedlemskapResource getMedlemskap(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
-        return medlemskapService.getMedlemskapResource(
-            Links.get(undervisningsgruppe.getMedlemskap()),
-            dfe);
+    public List<MedlemskapResource> getMedlemskap(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
+        return undervisningsgruppe.getMedlemskap()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.undervisningsgruppe;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResource;
-import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class UndervisningsgruppeService {
     @Autowired
     private Endpoints endpoints;
 
-    public UndervisningsgruppeResources getUndervisningsgruppeResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningTimeplan() + "/undervisningsgruppe",
-                    sinceTimeStamp),
-                UndervisningsgruppeResources.class,
-                dfe);
+    public UndervisningsgruppeResource getUndervisningsgruppeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getUndervisningsgruppeResource(
+            endpoints.getUtdanningTimeplan() 
+                + "/undervisningsgruppe/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public UndervisningsgruppeResource getUndervisningsgruppeResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/utdanningsprogram/UtdanningsprogramQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/utdanningsprogram/UtdanningsprogramQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.utdanningsprogram;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.utdanningsprogram.UtdanningsprogramResource;
-import no.fint.model.resource.utdanning.utdanningsprogram.UtdanningsprogramResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningUtdanningsprogramQueryResolver")
 public class UtdanningsprogramQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class UtdanningsprogramQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private UtdanningsprogramService service;
 
-    public List<UtdanningsprogramResource> getUtdanningsprogram(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        UtdanningsprogramResources resources = service.getUtdanningsprogramResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public UtdanningsprogramResource getUtdanningsprogram(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getUtdanningsprogramResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/utdanningsprogram/UtdanningsprogramResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/utdanningsprogram/UtdanningsprogramResolver.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningUtdanningsprogramResolver")
@@ -37,26 +38,29 @@ public class UtdanningsprogramResolver implements GraphQLResolver<Utdanningsprog
 
     public List<SkoleResource> getSkole(UtdanningsprogramResource utdanningsprogram, DataFetchingEnvironment dfe) {
         return utdanningsprogram.getSkole()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> skoleService.getSkoleResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> skoleService.getSkoleResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<ProgramomradeResource> getProgramomrade(UtdanningsprogramResource utdanningsprogram, DataFetchingEnvironment dfe) {
         return utdanningsprogram.getProgramomrade()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> programomradeService.getProgramomradeResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> programomradeService.getProgramomradeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<MedlemskapResource> getMedlemskap(UtdanningsprogramResource utdanningsprogram, DataFetchingEnvironment dfe) {
         return utdanningsprogram.getMedlemskap()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-            .collect(Collectors.toList());
+                .stream()
+                .map(Link::getHref)
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/utdanningsprogram/UtdanningsprogramResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/utdanningsprogram/UtdanningsprogramResolver.java
@@ -4,30 +4,26 @@ package no.fint.graphql.model.utdanning.utdanningsprogram;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.utdanning.skole.SkoleService;
 import no.fint.graphql.model.utdanning.programomrade.ProgramomradeService;
 import no.fint.graphql.model.utdanning.medlemskap.MedlemskapService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.utdanningsprogram.UtdanningsprogramResource;
-
-
 import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
 import no.fint.model.resource.utdanning.utdanningsprogram.ProgramomradeResource;
 import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningUtdanningsprogramResolver")
 public class UtdanningsprogramResolver implements GraphQLResolver<UtdanningsprogramResource> {
-
 
     @Autowired
     private SkoleService skoleService;
@@ -39,22 +35,28 @@ public class UtdanningsprogramResolver implements GraphQLResolver<Utdanningsprog
     private MedlemskapService medlemskapService;
 
 
-    public SkoleResource getSkole(UtdanningsprogramResource utdanningsprogram, DataFetchingEnvironment dfe) {
-        return skoleService.getSkoleResource(
-            Links.get(utdanningsprogram.getSkole()),
-            dfe);
+    public List<SkoleResource> getSkole(UtdanningsprogramResource utdanningsprogram, DataFetchingEnvironment dfe) {
+        return utdanningsprogram.getSkole()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> skoleService.getSkoleResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public ProgramomradeResource getProgramomrade(UtdanningsprogramResource utdanningsprogram, DataFetchingEnvironment dfe) {
-        return programomradeService.getProgramomradeResource(
-            Links.get(utdanningsprogram.getProgramomrade()),
-            dfe);
+    public List<ProgramomradeResource> getProgramomrade(UtdanningsprogramResource utdanningsprogram, DataFetchingEnvironment dfe) {
+        return utdanningsprogram.getProgramomrade()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> programomradeService.getProgramomradeResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
-    public MedlemskapResource getMedlemskap(UtdanningsprogramResource utdanningsprogram, DataFetchingEnvironment dfe) {
-        return medlemskapService.getMedlemskapResource(
-            Links.get(utdanningsprogram.getMedlemskap()),
-            dfe);
+    public List<MedlemskapResource> getMedlemskap(UtdanningsprogramResource utdanningsprogram, DataFetchingEnvironment dfe) {
+        return utdanningsprogram.getMedlemskap()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/utdanningsprogram/UtdanningsprogramService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/utdanningsprogram/UtdanningsprogramService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.utdanningsprogram;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.utdanningsprogram.UtdanningsprogramResource;
-import no.fint.model.resource.utdanning.utdanningsprogram.UtdanningsprogramResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class UtdanningsprogramService {
     @Autowired
     private Endpoints endpoints;
 
-    public UtdanningsprogramResources getUtdanningsprogramResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningUtdanningsprogram() + "/utdanningsprogram",
-                    sinceTimeStamp),
-                UtdanningsprogramResources.class,
-                dfe);
+    public UtdanningsprogramResource getUtdanningsprogramResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getUtdanningsprogramResource(
+            endpoints.getUtdanningUtdanningsprogram() 
+                + "/utdanningsprogram/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public UtdanningsprogramResource getUtdanningsprogramResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingQueryResolver.java
@@ -5,11 +5,9 @@ package no.fint.graphql.model.utdanning.vurdering;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import no.fint.model.resource.utdanning.vurdering.VurderingResource;
-import no.fint.model.resource.utdanning.vurdering.VurderingResources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("utdanningVurderingQueryResolver")
 public class VurderingQueryResolver implements GraphQLQueryResolver {
@@ -17,8 +15,12 @@ public class VurderingQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private VurderingService service;
 
-    public List<VurderingResource> getVurdering(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        VurderingResources resources = service.getVurderingResources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public VurderingResource getVurdering(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getVurderingResourceById("systemid", systemId, dfe);
+        }
+        return null;
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingResolver.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("utdanningVurderingResolver")
@@ -42,34 +43,38 @@ public class VurderingResolver implements GraphQLResolver<VurderingResource> {
 
     public ElevforholdResource getElevforhold(VurderingResource vurdering, DataFetchingEnvironment dfe) {
         return vurdering.getElevforhold()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> elevforholdService.getElevforholdResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> elevforholdService.getElevforholdResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public UndervisningsgruppeResource getUndervisningsgruppe(VurderingResource vurdering, DataFetchingEnvironment dfe) {
         return vurdering.getUndervisningsgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public EksamensgruppeResource getEksamensgruppe(VurderingResource vurdering, DataFetchingEnvironment dfe) {
         return vurdering.getEksamensgruppe()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
     public KarakterverdiResource getKarakter(VurderingResource vurdering, DataFetchingEnvironment dfe) {
         return vurdering.getKarakter()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> karakterverdiService.getKarakterverdiResource(l, dfe))
-            .findFirst().orElse(null);
+                .stream()
+                .map(Link::getHref)
+                .map(l -> karakterverdiService.getKarakterverdiResource(l, dfe))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingResolver.java
@@ -4,10 +4,6 @@ package no.fint.graphql.model.utdanning.vurdering;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
-
-
-
 
 import no.fint.graphql.model.utdanning.elevforhold.ElevforholdService;
 import no.fint.graphql.model.utdanning.undervisningsgruppe.UndervisningsgruppeService;
@@ -15,21 +11,21 @@ import no.fint.graphql.model.utdanning.eksamensgruppe.EksamensgruppeService;
 import no.fint.graphql.model.utdanning.karakterverdi.KarakterverdiService;
 
 
+import no.fint.model.resource.Link;
 import no.fint.model.resource.utdanning.vurdering.VurderingResource;
-
-
 import no.fint.model.resource.utdanning.elev.ElevforholdResource;
 import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResource;
 import no.fint.model.resource.utdanning.vurdering.EksamensgruppeResource;
 import no.fint.model.resource.utdanning.vurdering.KarakterverdiResource;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("utdanningVurderingResolver")
 public class VurderingResolver implements GraphQLResolver<VurderingResource> {
-
 
     @Autowired
     private ElevforholdService elevforholdService;
@@ -45,27 +41,35 @@ public class VurderingResolver implements GraphQLResolver<VurderingResource> {
 
 
     public ElevforholdResource getElevforhold(VurderingResource vurdering, DataFetchingEnvironment dfe) {
-        return elevforholdService.getElevforholdResource(
-            Links.get(vurdering.getElevforhold()),
-            dfe);
+        return vurdering.getElevforhold()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> elevforholdService.getElevforholdResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public UndervisningsgruppeResource getUndervisningsgruppe(VurderingResource vurdering, DataFetchingEnvironment dfe) {
-        return undervisningsgruppeService.getUndervisningsgruppeResource(
-            Links.get(vurdering.getUndervisningsgruppe()),
-            dfe);
+        return vurdering.getUndervisningsgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public EksamensgruppeResource getEksamensgruppe(VurderingResource vurdering, DataFetchingEnvironment dfe) {
-        return eksamensgruppeService.getEksamensgruppeResource(
-            Links.get(vurdering.getEksamensgruppe()),
-            dfe);
+        return vurdering.getEksamensgruppe()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
     public KarakterverdiResource getKarakter(VurderingResource vurdering, DataFetchingEnvironment dfe) {
-        return karakterverdiService.getKarakterverdiResource(
-            Links.get(vurdering.getKarakter()),
-            dfe);
+        return vurdering.getKarakter()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> karakterverdiService.getKarakterverdiResource(l, dfe))
+            .findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingService.java
@@ -3,11 +3,9 @@
 package no.fint.graphql.model.utdanning.vurdering;
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.vurdering.VurderingResource;
-import no.fint.model.resource.utdanning.vurdering.VurderingResources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +18,14 @@ public class VurderingService {
     @Autowired
     private Endpoints endpoints;
 
-    public VurderingResources getVurderingResources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.getUtdanningVurdering() + "/vurdering",
-                    sinceTimeStamp),
-                VurderingResources.class,
-                dfe);
+    public VurderingResource getVurderingResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getVurderingResource(
+            endpoints.getUtdanningVurdering() 
+                + "/vurdering/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public VurderingResource getVurderingResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/resources/schema/administrasjon/ansvar.graphqls
+++ b/src/main/resources/schema/administrasjon/ansvar.graphqls
@@ -11,7 +11,7 @@ type Ansvar {
 
 	# Relations
     overordnet: Ansvar
-    underordnet: Ansvar
-    organisasjonselement: Organisasjonselement
-    fullmakt: Fullmakt
+    underordnet: [Ansvar]
+    organisasjonselement: [Organisasjonselement]
+    fullmakt: [Fullmakt]
 }

--- a/src/main/resources/schema/administrasjon/arbeidsforhold.graphqls
+++ b/src/main/resources/schema/administrasjon/arbeidsforhold.graphqls
@@ -19,9 +19,9 @@ type Arbeidsforhold {
     funksjon: Funksjon
     stillingskode: Stillingskode
     timerPerUke: Uketimetall
-    arbeidssted: Organisasjonselement
+    arbeidssted: Organisasjonselement!
     personalleder: Personalressurs
     lonn: String
-    personalressurs: Personalressurs
+    personalressurs: Personalressurs!
     undervisningsforhold: Undervisningsforhold
 }

--- a/src/main/resources/schema/administrasjon/arbeidsforhold.graphqls
+++ b/src/main/resources/schema/administrasjon/arbeidsforhold.graphqls
@@ -21,7 +21,7 @@ type Arbeidsforhold {
     timerPerUke: Uketimetall
     arbeidssted: Organisasjonselement!
     personalleder: Personalressurs
-    lonn: String
+    lonn: [String]
     personalressurs: Personalressurs!
     undervisningsforhold: Undervisningsforhold
 }

--- a/src/main/resources/schema/administrasjon/art.graphqls
+++ b/src/main/resources/schema/administrasjon/art.graphqls
@@ -10,5 +10,5 @@ type Art {
 
 
 	# Relations
-    fullmakt: Fullmakt
+    fullmakt: [Fullmakt]
 }

--- a/src/main/resources/schema/administrasjon/fastlonn.graphqls
+++ b/src/main/resources/schema/administrasjon/fastlonn.graphqls
@@ -18,5 +18,5 @@ type Fastlonn {
     anviser: Personalressurs
     konterer: Personalressurs
     attestant: Personalressurs
-    arbeidsforhold: Arbeidsforhold
+    arbeidsforhold: Arbeidsforhold!
 }

--- a/src/main/resources/schema/administrasjon/fasttillegg.graphqls
+++ b/src/main/resources/schema/administrasjon/fasttillegg.graphqls
@@ -14,9 +14,9 @@ type Fasttillegg {
 
 
 	# Relations
-    lonnsart: Lonnsart
+    lonnsart: Lonnsart!
     anviser: Personalressurs
     konterer: Personalressurs
     attestant: Personalressurs
-    arbeidsforhold: Arbeidsforhold
+    arbeidsforhold: Arbeidsforhold!
 }

--- a/src/main/resources/schema/administrasjon/fullmakt.graphqls
+++ b/src/main/resources/schema/administrasjon/fullmakt.graphqls
@@ -7,7 +7,7 @@ type Fullmakt {
 
 
 	# Relations
-    myndighet: String
+    myndighet: [String]
     stedfortreder: Personalressurs
     fullmektig: Personalressurs
     rolle: Rolle!

--- a/src/main/resources/schema/administrasjon/fullmakt.graphqls
+++ b/src/main/resources/schema/administrasjon/fullmakt.graphqls
@@ -10,5 +10,5 @@ type Fullmakt {
     myndighet: String
     stedfortreder: Personalressurs
     fullmektig: Personalressurs
-    rolle: Rolle
+    rolle: Rolle!
 }

--- a/src/main/resources/schema/administrasjon/funksjon.graphqls
+++ b/src/main/resources/schema/administrasjon/funksjon.graphqls
@@ -11,6 +11,6 @@ type Funksjon {
 
 	# Relations
     overordnet: Funksjon
-    underordnet: Funksjon
-    fullmakt: Fullmakt
+    underordnet: [Funksjon]
+    fullmakt: [Fullmakt]
 }

--- a/src/main/resources/schema/administrasjon/kontostreng.graphqls
+++ b/src/main/resources/schema/administrasjon/kontostreng.graphqls
@@ -4,8 +4,8 @@ type Kontostreng {
 
 
 	# Relations
-    ansvar: Ansvar
-    art: Art
-    funksjon: Funksjon
+    ansvar: Ansvar!
+    art: Art!
+    funksjon: Funksjon!
     prosjekt: Prosjekt
 }

--- a/src/main/resources/schema/administrasjon/organisasjonselement.graphqls
+++ b/src/main/resources/schema/administrasjon/organisasjonselement.graphqls
@@ -15,10 +15,10 @@ type Organisasjonselement {
 
 
 	# Relations
-    ansvar: Ansvar
+    ansvar: [Ansvar]
     leder: Personalressurs
-    overordnet: Organisasjonselement
-    underordnet: Organisasjonselement
+    overordnet: Organisasjonselement!
+    underordnet: [Organisasjonselement]
     skole: Skole
-    arbeidsforhold: Arbeidsforhold
+    arbeidsforhold: [Arbeidsforhold]
 }

--- a/src/main/resources/schema/administrasjon/personalressurs.graphqls
+++ b/src/main/resources/schema/administrasjon/personalressurs.graphqls
@@ -11,12 +11,12 @@ type Personalressurs {
 
 
 	# Relations
-    personalressurskategori: Personalressurskategori
-    arbeidsforhold: Arbeidsforhold
-    person: Person
-    stedfortreder: Fullmakt
-    fullmakt: Fullmakt
-    leder: Organisasjonselement
-    personalansvar: Arbeidsforhold
+    personalressurskategori: Personalressurskategori!
+    arbeidsforhold: [Arbeidsforhold]
+    person: Person!
+    stedfortreder: [Fullmakt]
+    fullmakt: [Fullmakt]
+    leder: [Organisasjonselement]
+    personalansvar: [Arbeidsforhold]
     skoleressurs: Skoleressurs
 }

--- a/src/main/resources/schema/administrasjon/prosjekt.graphqls
+++ b/src/main/resources/schema/administrasjon/prosjekt.graphqls
@@ -10,5 +10,5 @@ type Prosjekt {
 
 
 	# Relations
-    fullmakt: Fullmakt
+    fullmakt: [Fullmakt]
 }

--- a/src/main/resources/schema/administrasjon/rolle.graphqls
+++ b/src/main/resources/schema/administrasjon/rolle.graphqls
@@ -7,5 +7,5 @@ type Rolle {
 
 
 	# Relations
-    fullmakt: Fullmakt
+    fullmakt: [Fullmakt]!
 }

--- a/src/main/resources/schema/administrasjon/variabellonn.graphqls
+++ b/src/main/resources/schema/administrasjon/variabellonn.graphqls
@@ -15,9 +15,9 @@ type Variabellonn {
 
 
 	# Relations
-    lonnsart: Lonnsart
+    lonnsart: Lonnsart!
     anviser: Personalressurs
     konterer: Personalressurs
     attestant: Personalressurs
-    arbeidsforhold: Arbeidsforhold
+    arbeidsforhold: Arbeidsforhold!
 }

--- a/src/main/resources/schema/felles/fylke.graphqls
+++ b/src/main/resources/schema/felles/fylke.graphqls
@@ -10,5 +10,5 @@ type Fylke {
 
 
 	# Relations
-    kommune: Kommune
+    kommune: [Kommune]
 }

--- a/src/main/resources/schema/felles/kommune.graphqls
+++ b/src/main/resources/schema/felles/kommune.graphqls
@@ -10,5 +10,5 @@ type Kommune {
 
 
 	# Relations
-    fylke: Fylke
+    fylke: Fylke!
 }

--- a/src/main/resources/schema/felles/kontaktperson.graphqls
+++ b/src/main/resources/schema/felles/kontaktperson.graphqls
@@ -9,5 +9,5 @@ type Kontaktperson {
 
 	# Relations
     kontaktperson: Person
-    person: Person
+    person: Person!
 }

--- a/src/main/resources/schema/felles/person.graphqls
+++ b/src/main/resources/schema/felles/person.graphqls
@@ -12,11 +12,11 @@ type Person {
 
 
 	# Relations
-    statsborgerskap: Landkode
+    statsborgerskap: [Landkode]
     kjonn: Kjonn
     malform: Sprak
     personalressurs: Personalressurs
     morsmal: Sprak
-    parorende: Kontaktperson
+    parorende: [Kontaktperson]
     elev: Elev
 }

--- a/src/main/resources/schema/root.graphqls
+++ b/src/main/resources/schema/root.graphqls
@@ -2,10 +2,29 @@
 scalar Date
 
 type Query {
-    personalressurs(sinceTimeStamp: String): [Personalressurs]
-    arbeidsforhold(sinceTimeStamp: String): [Arbeidsforhold]
-    person(sinceTimeStamp: String): [Person]
-    organisasjonselement(sinceTimeStamp: String): [Organisasjonselement]
-
-    elev(sinceTimeStamp: String): [Elev]
+	arbeidsforhold(systemId: String): Arbeidsforhold
+	arstrinn(systemId: String): Arstrinn
+	basisgruppe(systemId: String): Basisgruppe
+	eksamensgruppe(systemId: String): Eksamensgruppe
+	elev(brukernavn: String, elevnummer: String, feidenavn: String, systemId: String): Elev
+	elevforhold(systemId: String): Elevforhold
+	fag(systemId: String): Fag
+	fullmakt(systemId: String): Fullmakt
+	karakterverdi(systemId: String): Karakterverdi
+	kontaktlarergruppe(systemId: String): Kontaktlarergruppe
+	kontaktperson(systemId: String): Kontaktperson
+	medlemskap(systemId: String): Medlemskap
+	organisasjonselement(organisasjonsId: String, organisasjonsKode: String, organisasjonsnummer: String): Organisasjonselement
+	person(fodselsnummer: String): Person
+	personalressurs(ansattnummer: String, brukernavn: String, systemId: String): Personalressurs
+	programomrade(systemId: String): Programomrade
+	rolle(navn: String): Rolle
+	rom(systemId: String): Rom
+	skole(skolenummer: String, systemId: String, organisasjonsnummer: String): Skole
+	skoleressurs(feidenavn: String, systemId: String): Skoleressurs
+	time(systemId: String): Time
+	undervisningsforhold(systemId: String): Undervisningsforhold
+	undervisningsgruppe(systemId: String): Undervisningsgruppe
+	utdanningsprogram(systemId: String): Utdanningsprogram
+	vurdering(systemId: String): Vurdering
 }

--- a/src/main/resources/schema/utdanning/arstrinn.graphqls
+++ b/src/main/resources/schema/utdanning/arstrinn.graphqls
@@ -11,7 +11,7 @@ type Arstrinn {
 	# Relations
     programomrade: [Programomrade]
     basisgruppe: [Basisgruppe]
-    grepreferanse: String
-    vigoreferanse: String
+    grepreferanse: [String]
+    vigoreferanse: [String]
     medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/arstrinn.graphqls
+++ b/src/main/resources/schema/utdanning/arstrinn.graphqls
@@ -9,9 +9,9 @@ type Arstrinn {
 
 
 	# Relations
-    programomrade: Programomrade
-    basisgruppe: Basisgruppe
+    programomrade: [Programomrade]
+    basisgruppe: [Basisgruppe]
     grepreferanse: String
     vigoreferanse: String
-    medlemskap: Medlemskap
+    medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/basisgruppe.graphqls
+++ b/src/main/resources/schema/utdanning/basisgruppe.graphqls
@@ -14,7 +14,7 @@ type Basisgruppe {
     undervisningsforhold: [Undervisningsforhold]
     elevforhold: [Elevforhold]
     kontaktlarergruppe: [Kontaktlarergruppe]
-    grepreferanse: String
-    vigoreferanse: String
+    grepreferanse: [String]
+    vigoreferanse: [String]
     medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/basisgruppe.graphqls
+++ b/src/main/resources/schema/utdanning/basisgruppe.graphqls
@@ -9,12 +9,12 @@ type Basisgruppe {
 
 
 	# Relations
-    trinn: Arstrinn
-    skole: Skole
-    undervisningsforhold: Undervisningsforhold
-    elevforhold: Elevforhold
-    kontaktlarergruppe: Kontaktlarergruppe
+    trinn: Arstrinn!
+    skole: Skole!
+    undervisningsforhold: [Undervisningsforhold]
+    elevforhold: [Elevforhold]
+    kontaktlarergruppe: [Kontaktlarergruppe]
     grepreferanse: String
     vigoreferanse: String
-    medlemskap: Medlemskap
+    medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/eksamensgruppe.graphqls
+++ b/src/main/resources/schema/utdanning/eksamensgruppe.graphqls
@@ -9,11 +9,11 @@ type Eksamensgruppe {
 
 
 	# Relations
-    fag: Fag
-    skole: Skole
-    elevforhold: Elevforhold
-    undervisningsforhold: Undervisningsforhold
+    fag: Fag!
+    skole: Skole!
+    elevforhold: [Elevforhold]
+    undervisningsforhold: [Undervisningsforhold]
     grepreferanse: String
     vigoreferanse: String
-    medlemskap: Medlemskap
+    medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/eksamensgruppe.graphqls
+++ b/src/main/resources/schema/utdanning/eksamensgruppe.graphqls
@@ -13,7 +13,7 @@ type Eksamensgruppe {
     skole: Skole!
     elevforhold: [Elevforhold]
     undervisningsforhold: [Undervisningsforhold]
-    grepreferanse: String
-    vigoreferanse: String
+    grepreferanse: [String]
+    vigoreferanse: [String]
     medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/elev.graphqls
+++ b/src/main/resources/schema/utdanning/elev.graphqls
@@ -10,6 +10,6 @@ type Elev {
 
 
 	# Relations
-    person: Person
-    elevforhold: Elevforhold
+    person: Person!
+    elevforhold: [Elevforhold]
 }

--- a/src/main/resources/schema/utdanning/elevforhold.graphqls
+++ b/src/main/resources/schema/utdanning/elevforhold.graphqls
@@ -7,13 +7,13 @@ type Elevforhold {
 
 
 	# Relations
-    basisgruppe: Basisgruppe
-    elev: Elev
+    basisgruppe: [Basisgruppe]
+    elev: Elev!
     kategori: Elevkategori
-    skole: Skole
-    eksamensgruppe: Eksamensgruppe
-    kontaktlarergruppe: Kontaktlarergruppe
-    undervisningsgruppe: Undervisningsgruppe
-    vurdering: Vurdering
-    medlemskap: Medlemskap
+    skole: Skole!
+    eksamensgruppe: [Eksamensgruppe]
+    kontaktlarergruppe: [Kontaktlarergruppe]
+    undervisningsgruppe: [Undervisningsgruppe]
+    vurdering: [Vurdering]
+    medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/fag.graphqls
+++ b/src/main/resources/schema/utdanning/fag.graphqls
@@ -9,11 +9,11 @@ type Fag {
 
 
 	# Relations
-    programomrade: Programomrade
-    skole: Skole
-    undervisningsgruppe: Undervisningsgruppe
-    eksamensgruppe: Eksamensgruppe
+    programomrade: [Programomrade]
+    skole: [Skole]
+    undervisningsgruppe: [Undervisningsgruppe]
+    eksamensgruppe: [Eksamensgruppe]
     grepreferanse: String
     vigoreferanse: String
-    medlemskap: Medlemskap
+    medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/fag.graphqls
+++ b/src/main/resources/schema/utdanning/fag.graphqls
@@ -13,7 +13,7 @@ type Fag {
     skole: [Skole]
     undervisningsgruppe: [Undervisningsgruppe]
     eksamensgruppe: [Eksamensgruppe]
-    grepreferanse: String
-    vigoreferanse: String
+    grepreferanse: [String]
+    vigoreferanse: [String]
     medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/karakterskala.graphqls
+++ b/src/main/resources/schema/utdanning/karakterskala.graphqls
@@ -10,6 +10,6 @@ type Karakterskala {
 
 
 	# Relations
-    vigoreferanse: String
+    vigoreferanse: [String]
     verdi: [Karakterverdi]
 }

--- a/src/main/resources/schema/utdanning/karakterskala.graphqls
+++ b/src/main/resources/schema/utdanning/karakterskala.graphqls
@@ -11,5 +11,5 @@ type Karakterskala {
 
 	# Relations
     vigoreferanse: String
-    verdi: Karakterverdi
+    verdi: [Karakterverdi]
 }

--- a/src/main/resources/schema/utdanning/karakterverdi.graphqls
+++ b/src/main/resources/schema/utdanning/karakterverdi.graphqls
@@ -10,5 +10,5 @@ type Karakterverdi {
 
 
 	# Relations
-    skala: Karakterskala
+    skala: Karakterskala!
 }

--- a/src/main/resources/schema/utdanning/kontaktlarergruppe.graphqls
+++ b/src/main/resources/schema/utdanning/kontaktlarergruppe.graphqls
@@ -9,11 +9,11 @@ type Kontaktlarergruppe {
 
 
 	# Relations
-    basisgruppe: Basisgruppe
-    skole: Skole
-    elevforhold: Elevforhold
-    undervisningsforhold: Undervisningsforhold
+    basisgruppe: [Basisgruppe]!
+    skole: Skole!
+    elevforhold: [Elevforhold]
+    undervisningsforhold: [Undervisningsforhold]
     grepreferanse: String
     vigoreferanse: String
-    medlemskap: Medlemskap
+    medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/kontaktlarergruppe.graphqls
+++ b/src/main/resources/schema/utdanning/kontaktlarergruppe.graphqls
@@ -13,7 +13,7 @@ type Kontaktlarergruppe {
     skole: Skole!
     elevforhold: [Elevforhold]
     undervisningsforhold: [Undervisningsforhold]
-    grepreferanse: String
-    vigoreferanse: String
+    grepreferanse: [String]
+    vigoreferanse: [String]
     medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/medlemskap.graphqls
+++ b/src/main/resources/schema/utdanning/medlemskap.graphqls
@@ -6,8 +6,8 @@ type Medlemskap {
 
 
 	# Relations
-    medlem: String
+    medlem: [String]
     fortlopendeVurdering: [Vurdering]
-    gruppe: String
+    gruppe: [String]
     endeligVurdering: Vurdering
 }

--- a/src/main/resources/schema/utdanning/medlemskap.graphqls
+++ b/src/main/resources/schema/utdanning/medlemskap.graphqls
@@ -7,7 +7,7 @@ type Medlemskap {
 
 	# Relations
     medlem: String
-    fortlopendeVurdering: Vurdering
+    fortlopendeVurdering: [Vurdering]
     gruppe: String
     endeligVurdering: Vurdering
 }

--- a/src/main/resources/schema/utdanning/programomrade.graphqls
+++ b/src/main/resources/schema/utdanning/programomrade.graphqls
@@ -9,10 +9,10 @@ type Programomrade {
 
 
 	# Relations
-    utdanningsprogram: Utdanningsprogram
-    fag: Fag
-    trinn: Arstrinn
+    utdanningsprogram: Utdanningsprogram!
+    fag: [Fag]
+    trinn: [Arstrinn]
     grepreferanse: String
     vigoreferanse: String
-    medlemskap: Medlemskap
+    medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/programomrade.graphqls
+++ b/src/main/resources/schema/utdanning/programomrade.graphqls
@@ -12,7 +12,7 @@ type Programomrade {
     utdanningsprogram: Utdanningsprogram!
     fag: [Fag]
     trinn: [Arstrinn]
-    grepreferanse: String
-    vigoreferanse: String
+    grepreferanse: [String]
+    vigoreferanse: [String]
     medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/rom.graphqls
+++ b/src/main/resources/schema/utdanning/rom.graphqls
@@ -7,5 +7,5 @@ type Rom {
 
 
 	# Relations
-    time: Time
+    time: [Time]
 }

--- a/src/main/resources/schema/utdanning/skole.graphqls
+++ b/src/main/resources/schema/utdanning/skole.graphqls
@@ -18,7 +18,7 @@ type Skole {
     organisasjon: Organisasjonselement
     fag: [Fag]
     skoleeierType: Skoleeiertype
-    vigoreferanse: String
+    vigoreferanse: [String]
     basisgruppe: [Basisgruppe]
     elevforhold: [Elevforhold]
     kontaktlarergruppe: [Kontaktlarergruppe]

--- a/src/main/resources/schema/utdanning/skole.graphqls
+++ b/src/main/resources/schema/utdanning/skole.graphqls
@@ -16,15 +16,15 @@ type Skole {
 
 	# Relations
     organisasjon: Organisasjonselement
-    fag: Fag
+    fag: [Fag]
     skoleeierType: Skoleeiertype
     vigoreferanse: String
-    basisgruppe: Basisgruppe
-    elevforhold: Elevforhold
-    kontaktlarergruppe: Kontaktlarergruppe
-    skoleressurs: Skoleressurs
-    undervisningsforhold: Undervisningsforhold
-    undervisningsgruppe: Undervisningsgruppe
-    eksamensgruppe: Eksamensgruppe
-    utdanningsprogram: Utdanningsprogram
+    basisgruppe: [Basisgruppe]
+    elevforhold: [Elevforhold]
+    kontaktlarergruppe: [Kontaktlarergruppe]
+    skoleressurs: [Skoleressurs]
+    undervisningsforhold: [Undervisningsforhold]
+    undervisningsgruppe: [Undervisningsgruppe]
+    eksamensgruppe: [Eksamensgruppe]
+    utdanningsprogram: [Utdanningsprogram]
 }

--- a/src/main/resources/schema/utdanning/skoleressurs.graphqls
+++ b/src/main/resources/schema/utdanning/skoleressurs.graphqls
@@ -7,7 +7,7 @@ type Skoleressurs {
 
 
 	# Relations
-    personalressurs: Personalressurs
-    undervisningsforhold: Undervisningsforhold
-    skole: Skole
+    personalressurs: Personalressurs!
+    undervisningsforhold: [Undervisningsforhold]
+    skole: Skole!
 }

--- a/src/main/resources/schema/utdanning/time.graphqls
+++ b/src/main/resources/schema/utdanning/time.graphqls
@@ -9,7 +9,7 @@ type Time {
 
 
 	# Relations
-    undervisningsgruppe: Undervisningsgruppe
-    undervisningsforhold: Undervisningsforhold
-    rom: Rom
+    undervisningsgruppe: [Undervisningsgruppe]!
+    undervisningsforhold: [Undervisningsforhold]!
+    rom: [Rom]
 }

--- a/src/main/resources/schema/utdanning/undervisningsforhold.graphqls
+++ b/src/main/resources/schema/utdanning/undervisningsforhold.graphqls
@@ -7,13 +7,13 @@ type Undervisningsforhold {
 
 
 	# Relations
-    arbeidsforhold: Arbeidsforhold
-    basisgruppe: Basisgruppe
-    kontaktlarergruppe: Kontaktlarergruppe
-    undervisningsgruppe: Undervisningsgruppe
-    eksamensgruppe: Eksamensgruppe
-    time: Time
-    skole: Skole
-    skoleressurs: Skoleressurs
-    medlemskap: Medlemskap
+    arbeidsforhold: Arbeidsforhold!
+    basisgruppe: [Basisgruppe]
+    kontaktlarergruppe: [Kontaktlarergruppe]
+    undervisningsgruppe: [Undervisningsgruppe]
+    eksamensgruppe: [Eksamensgruppe]
+    time: [Time]
+    skole: Skole!
+    skoleressurs: Skoleressurs!
+    medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/undervisningsgruppe.graphqls
+++ b/src/main/resources/schema/utdanning/undervisningsgruppe.graphqls
@@ -9,12 +9,12 @@ type Undervisningsgruppe {
 
 
 	# Relations
-    fag: Fag
-    skole: Skole
-    elevforhold: Elevforhold
-    undervisningsforhold: Undervisningsforhold
-    time: Time
+    fag: [Fag]!
+    skole: Skole!
+    elevforhold: [Elevforhold]
+    undervisningsforhold: [Undervisningsforhold]
+    time: [Time]
     grepreferanse: String
     vigoreferanse: String
-    medlemskap: Medlemskap
+    medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/undervisningsgruppe.graphqls
+++ b/src/main/resources/schema/utdanning/undervisningsgruppe.graphqls
@@ -14,7 +14,7 @@ type Undervisningsgruppe {
     elevforhold: [Elevforhold]
     undervisningsforhold: [Undervisningsforhold]
     time: [Time]
-    grepreferanse: String
-    vigoreferanse: String
+    grepreferanse: [String]
+    vigoreferanse: [String]
     medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/utdanningsprogram.graphqls
+++ b/src/main/resources/schema/utdanning/utdanningsprogram.graphqls
@@ -11,7 +11,7 @@ type Utdanningsprogram {
 	# Relations
     skole: [Skole]
     programomrade: [Programomrade]
-    grepreferanse: String
-    vigoreferanse: String
+    grepreferanse: [String]
+    vigoreferanse: [String]
     medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/utdanningsprogram.graphqls
+++ b/src/main/resources/schema/utdanning/utdanningsprogram.graphqls
@@ -9,9 +9,9 @@ type Utdanningsprogram {
 
 
 	# Relations
-    skole: Skole
-    programomrade: Programomrade
+    skole: [Skole]
+    programomrade: [Programomrade]
     grepreferanse: String
     vigoreferanse: String
-    medlemskap: Medlemskap
+    medlemskap: [Medlemskap]
 }

--- a/src/main/resources/schema/utdanning/vurdering.graphqls
+++ b/src/main/resources/schema/utdanning/vurdering.graphqls
@@ -8,8 +8,8 @@ type Vurdering {
 
 
 	# Relations
-    elevforhold: Elevforhold
+    elevforhold: Elevforhold!
     undervisningsgruppe: Undervisningsgruppe
     eksamensgruppe: Eksamensgruppe
-    karakter: Karakterverdi
+    karakter: Karakterverdi!
 }


### PR DESCRIPTION
With this PR all queries start by looking up an individual resource by `Identifikator` and then traversing relations.

Returning large sets of deeply linked data quickly becomes infeasible, and is better supported by the existing REST API.

The two can be combined by using an initial REST call to get a set of candidate identifiers to enrich using GraphQL.