### PR TITLE
Use WebClient Mono / Flux to perform asynchronous requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@
 /dist/
 /nbdist/
 /.nb-gradle/
+
+### Visual Studio Code / Eclipse ###
+/.classpath
+/.settings/
+/.project
+/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ USER root
 COPY . .
 RUN gradle --no-daemon build
 
-FROM gcr.io/distroless/java
+FROM gcr.io/distroless/java:8
 ENV JAVA_TOOL_OPTIONS -XX:+ExitOnOutOfMemoryError
 COPY --from=builder /home/gradle/build/deps/external/*.jar /data/
 COPY --from=builder /home/gradle/build/deps/fint/*.jar /data/

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.1.2.RELEASE'
+        springBootVersion = '2.2.2.RELEASE'
     }
     repositories {
         jcenter()
@@ -11,7 +11,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.ben-manes.versions' version '0.20.0'
+    id 'com.github.ben-manes.versions' version '0.27.0'
 }
 
 apply plugin: 'java'
@@ -34,19 +34,20 @@ repositories {
 
 apply from: 'https://raw.githubusercontent.com/FINTlibs/fint-buildscripts/master/dependencies.gradle'
 
-cglibVersion = '3.2.10'
-lombokVersion = '1.18.4'
-spockSpringVersion = '1.2-RC3-groovy-2.5'
+cglibVersion = '3.3.0'
+lombokVersion = '1.18.10'
+spockSpringVersion = '1.3-RC1-groovy-2.5'
 
 dependencies {
     compile('no.fint:fint-model-resource:0.3.3')
     compile("no.fint:fint-utdanning-resource-model-java:${apiVersion}")
     compile("no.fint:fint-administrasjon-resource-model-java:${apiVersion}")
 
-    compile('com.graphql-java-kickstart:graphql-spring-boot-starter:5.4')
-    compile('com.graphql-java-kickstart:graphiql-spring-boot-starter:5.4')
-    compile('com.graphql-java-kickstart:graphql-java-tools:5.4.1')
-    compile('com.zhokhov.graphql:graphql-datetime-spring-boot-starter:1.4.0')
+    compile('com.graphql-java-kickstart:graphql-kickstart-spring-boot-starter-webflux:6.0.0')
+    compile('com.graphql-java-kickstart:graphql-spring-boot-starter:6.0.0')
+    compile('com.graphql-java-kickstart:graphiql-spring-boot-starter:6.0.0')
+    compile('com.graphql-java-kickstart:graphql-java-tools:5.7.1')
+    compile('com.zhokhov.graphql:graphql-datetime-spring-boot-starter:1.6.0')
 
     compile('org.springframework.boot:spring-boot-starter-webflux')
     compile('org.springframework.boot:spring-boot-starter')

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.2.2.RELEASE'
+        springBootVersion = '2.2.4.RELEASE'
     }
     repositories {
         jcenter()
@@ -43,9 +43,9 @@ dependencies {
     compile("no.fint:fint-utdanning-resource-model-java:${apiVersion}")
     compile("no.fint:fint-administrasjon-resource-model-java:${apiVersion}")
 
-    compile('com.graphql-java-kickstart:graphql-kickstart-spring-boot-starter-webflux:6.0.0')
-    compile('com.graphql-java-kickstart:graphql-spring-boot-starter:6.0.0')
-    compile('com.graphql-java-kickstart:graphiql-spring-boot-starter:6.0.0')
+    compile('com.graphql-java-kickstart:graphql-kickstart-spring-boot-starter-tools:6.0.1')
+    compile('com.graphql-java-kickstart:graphql-spring-boot-starter:6.0.1')
+    compile('com.graphql-java-kickstart:graphiql-spring-boot-starter:6.0.1')
     compile('com.graphql-java-kickstart:graphql-java-tools:5.7.1')
     compile('com.zhokhov.graphql:graphql-datetime-spring-boot-starter:1.6.0')
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ version=3.3.0
 apiVersion=3.2.0
 
 # GraphQL Java Tools: NoClassDefFoundError when using Spring Boot
-kotlin.version=1.3.10
+#kotlin.version=1.3.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=3.3.0
-apiVersion=3.2.0
+apiVersion=3.4.0
 
 # GraphQL Java Tools: NoClassDefFoundError when using Spring Boot
 #kotlin.version=1.3.10

--- a/k8s-beta.yaml
+++ b/k8s-beta.yaml
@@ -53,6 +53,10 @@ spec:
             limits:
               memory: "5Gi"
               cpu: "2"
+          envFrom:
+            - configMapRef:
+                name: fint-environment
+                optional: true
           env:
             - name: TZ
               value: Europe/Oslo
@@ -68,3 +72,5 @@ spec:
               value: "true"
             - name: spring.codec.max-in-memory-size
               value: "50000000"
+            - name: fint.webclient.connection-provider.maxLifeTime
+              value: "PT15M"

--- a/k8s-beta.yaml
+++ b/k8s-beta.yaml
@@ -44,7 +44,7 @@ spec:
           ports:
             - containerPort: 8080
           readinessProbe:
-            initialDelaySeconds: 30
+            initialDelaySeconds: 20
             timeoutSeconds: 5
             httpGet:
               port: 8080

--- a/k8s-beta.yaml
+++ b/k8s-beta.yaml
@@ -22,7 +22,7 @@ metadata:
     io.kompose.service: graphql-beta
   name: graphql-beta
 spec:
-  replicas: 1
+  replicas: 3
   minReadySeconds: 30
   revisionHistoryLimit: 0
   strategy:
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
         - name: graphql-beta
-          image: fintlabs.azurecr.io/graphql:1.0.0
+          image: fintlabs.azurecr.io/graphql:PR-16.1
           ports:
             - containerPort: 8080
           readinessProbe:
@@ -51,18 +51,20 @@ spec:
               path: /graphql/actuator/health
           resources:
             limits:
-              memory: "1.5Gi"
-              cpu: "1000m"
+              memory: "5Gi"
+              cpu: "2"
           env:
             - name: TZ
               value: Europe/Oslo
             - name: JAVA_OPTS
-              value: -Xmx1G
+              value: -Xmx4G
             - name: server.servlet.context-path
               value: "/graphql"
             - name: graphiql.endpoint.graphql
               value: "/graphql/graphql"
             - name: fint.endpoint.root
               value: "https://beta.felleskomponent.no"
-            - name: logging.level.org.springframework.web.reactive.function.client.ExchangeFunctions
-              value: "DEBUG"
+            - name: spring.main.allow-bean-definition-overriding
+              value: "true"
+            - name: spring.codec.max-in-memory-size
+              value: "50000000"

--- a/src/main/java/no/fint/graphql/ApplicationConfig.java
+++ b/src/main/java/no/fint/graphql/ApplicationConfig.java
@@ -8,7 +8,6 @@ import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.http.client.reactive.ReactorResourceFactory;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
-import reactor.netty.resources.ConnectionProvider;
 
 @Configuration
 @Slf4j
@@ -19,7 +18,7 @@ public class ApplicationConfig {
 
     @Bean
     public WebClient webClient(WebClient.Builder builder, ReactorResourceFactory factory) {
-        factory.setConnectionProvider(ConnectionProvider.newConnection());
+        //factory.setConnectionProvider(ConnectionProvider.fixed("graphql"));
         return builder
                 .clientConnector(new ReactorClientHttpConnector(factory, HttpClient::secure))
                 .baseUrl(rootUri)

--- a/src/main/java/no/fint/graphql/ConnectionProviderSettings.java
+++ b/src/main/java/no/fint/graphql/ConnectionProviderSettings.java
@@ -1,0 +1,19 @@
+package no.fint.graphql;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import reactor.netty.resources.ConnectionProvider;
+
+import java.time.Duration;
+
+@ConfigurationProperties("fint.webclient.connection-provider")
+@Component
+@Data
+public class ConnectionProviderSettings {
+    private String type = "fixed";
+    private int maxConnections = ConnectionProvider.DEFAULT_POOL_MAX_CONNECTIONS;
+    private long acquireTimeout = ConnectionProvider.DEFAULT_POOL_ACQUIRE_TIMEOUT;
+    private Duration maxIdleTime;
+    private Duration maxLifeTime;
+}

--- a/src/main/java/no/fint/graphql/WebClientRequest.java
+++ b/src/main/java/no/fint/graphql/WebClientRequest.java
@@ -12,6 +12,7 @@ import org.springframework.web.util.UriBuilder;
 import reactor.core.publisher.Mono;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.function.Function;
 
 @Slf4j
@@ -41,7 +42,8 @@ public class WebClientRequest {
         }
         return request.retrieve()
                 .onStatus(HttpStatus::is4xxClientError, r -> Mono.empty())
-                .bodyToMono(type);
+                .bodyToMono(type)
+                .retryBackoff(5, Duration.ofMillis(500));
     }
 
     private String getToken(DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/WebClientRequest.java
+++ b/src/main/java/no/fint/graphql/WebClientRequest.java
@@ -22,16 +22,18 @@ public class WebClientRequest {
     private WebClient webClient;
 
     public <T> T get(Function<UriBuilder, URI> uri, Class<T> type, DataFetchingEnvironment dfe) {
-        WebClient.RequestHeadersSpec<?> request = webClient.get().uri(uri);
-        return get(request, type, dfe);
+        return get(webClient.get().uri(uri), type, dfe).block();
     }
 
     public <T> T get(String uri, Class<T> type, DataFetchingEnvironment dfe) {
-        WebClient.RequestHeadersSpec<?> request = webClient.get().uri(uri);
-        return get(request, type, dfe);
+        return get(webClient.get().uri(uri), type, dfe).block();
     }
 
-    private <T> T get(WebClient.RequestHeadersSpec<?> request, Class<T> type, DataFetchingEnvironment dfe) {
+    public <T> Mono<T> getMono(String uri, Class<T> type, DataFetchingEnvironment dfe) {
+        return get(webClient.get().uri(uri), type, dfe);
+    }
+
+    private <T> Mono<T> get(WebClient.RequestHeadersSpec<?> request, Class<T> type, DataFetchingEnvironment dfe) {
         String token = getToken(dfe);
         log.debug("Token: {}", token);
         if (token != null) {
@@ -39,8 +41,7 @@ public class WebClientRequest {
         }
         return request.retrieve()
                 .onStatus(HttpStatus::is4xxClientError, r -> Mono.empty())
-                .bodyToMono(type)
-                .block();
+                .bodyToMono(type);
     }
 
     private String getToken(DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/WebClientRequest.java
+++ b/src/main/java/no/fint/graphql/WebClientRequest.java
@@ -8,12 +8,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.util.UriBuilder;
 import reactor.core.publisher.Mono;
 
-import java.net.URI;
 import java.time.Duration;
-import java.util.function.Function;
 
 @Slf4j
 @Component
@@ -22,15 +19,7 @@ public class WebClientRequest {
     @Autowired
     private WebClient webClient;
 
-    public <T> T get(Function<UriBuilder, URI> uri, Class<T> type, DataFetchingEnvironment dfe) {
-        return get(webClient.get().uri(uri), type, dfe).block();
-    }
-
-    public <T> T get(String uri, Class<T> type, DataFetchingEnvironment dfe) {
-        return get(webClient.get().uri(uri), type, dfe).block();
-    }
-
-    public <T> Mono<T> getMono(String uri, Class<T> type, DataFetchingEnvironment dfe) {
+    public <T> Mono<T> get(String uri, Class<T> type, DataFetchingEnvironment dfe) {
         return get(webClient.get().uri(uri), type, dfe);
     }
 

--- a/src/main/java/no/fint/graphql/WebClientRequest.java
+++ b/src/main/java/no/fint/graphql/WebClientRequest.java
@@ -1,7 +1,7 @@
 package no.fint.graphql;
 
 import graphql.schema.DataFetchingEnvironment;
-import graphql.servlet.GraphQLContext;
+import graphql.servlet.context.GraphQLServletContext;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -44,11 +44,9 @@ public class WebClientRequest {
     }
 
     private String getToken(DataFetchingEnvironment dfe) {
-        Object context = dfe.getExecutionContext().getContext();
-        if (context instanceof GraphQLContext) {
-            return ((GraphQLContext) context).getHttpServletRequest()
-                    .map(r -> r.getHeader(HttpHeaders.AUTHORIZATION))
-                    .orElse(null);
+        Object context = dfe.getContext();
+        if (context instanceof GraphQLServletContext) {
+            return ((GraphQLServletContext) context).getHttpServletRequest().getHeader(HttpHeaders.AUTHORIZATION);
         }
 
         return null;

--- a/src/main/java/no/fint/graphql/model/administrasjon/aktivitet/AktivitetQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/aktivitet/AktivitetQueryResolver.java
@@ -1,0 +1,28 @@
+
+package no.fint.graphql.model.administrasjon.aktivitet;
+
+import com.coxautodev.graphql.tools.GraphQLQueryResolver;
+import graphql.schema.DataFetchingEnvironment;
+import no.fint.model.resource.administrasjon.kodeverk.AktivitetResource;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
+
+@Component("administrasjonAktivitetQueryResolver")
+public class AktivitetQueryResolver implements GraphQLQueryResolver {
+
+    @Autowired
+    private AktivitetService service;
+
+    public CompletionStage<AktivitetResource> getAktivitet(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getAktivitetResourceById("systemid", systemId, dfe).toFuture();
+        }
+        return Mono.<AktivitetResource>empty().toFuture();
+    }
+}

--- a/src/main/java/no/fint/graphql/model/administrasjon/aktivitet/AktivitetResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/aktivitet/AktivitetResolver.java
@@ -1,0 +1,40 @@
+
+package no.fint.graphql.model.administrasjon.aktivitet;
+
+import com.coxautodev.graphql.tools.GraphQLResolver;
+import graphql.schema.DataFetchingEnvironment;
+
+import no.fint.graphql.model.administrasjon.fullmakt.FullmaktService;
+
+
+import no.fint.model.resource.Link;
+import no.fint.model.resource.administrasjon.kodeverk.AktivitetResource;
+import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+@Component("administrasjonAktivitetResolver")
+public class AktivitetResolver implements GraphQLResolver<AktivitetResource> {
+
+    @Autowired
+    private FullmaktService fullmaktService;
+
+
+    public CompletionStage<List<FullmaktResource>> getFullmakt(AktivitetResource aktivitet, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(aktivitet.getFullmakt()
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
+    }
+
+}
+

--- a/src/main/java/no/fint/graphql/model/administrasjon/aktivitet/AktivitetService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/aktivitet/AktivitetService.java
@@ -1,0 +1,35 @@
+
+package no.fint.graphql.model.administrasjon.aktivitet;
+
+import graphql.schema.DataFetchingEnvironment;
+import no.fint.graphql.WebClientRequest;
+import no.fint.graphql.model.Endpoints;
+import no.fint.model.resource.administrasjon.kodeverk.AktivitetResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service("administrasjonAktivitetService")
+public class AktivitetService {
+
+    @Autowired
+    private WebClientRequest webClientRequest;
+
+    @Autowired
+    private Endpoints endpoints;
+
+    public Mono<AktivitetResource> getAktivitetResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getAktivitetResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/aktivitet/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
+    }
+
+    public Mono<AktivitetResource> getAktivitetResource(String url, DataFetchingEnvironment dfe) {
+        return webClientRequest.get(url, AktivitetResource.class, dfe);
+    }
+}
+

--- a/src/main/java/no/fint/graphql/model/administrasjon/anlegg/AnleggQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/anlegg/AnleggQueryResolver.java
@@ -1,0 +1,28 @@
+
+package no.fint.graphql.model.administrasjon.anlegg;
+
+import com.coxautodev.graphql.tools.GraphQLQueryResolver;
+import graphql.schema.DataFetchingEnvironment;
+import no.fint.model.resource.administrasjon.kodeverk.AnleggResource;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
+
+@Component("administrasjonAnleggQueryResolver")
+public class AnleggQueryResolver implements GraphQLQueryResolver {
+
+    @Autowired
+    private AnleggService service;
+
+    public CompletionStage<AnleggResource> getAnlegg(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getAnleggResourceById("systemid", systemId, dfe).toFuture();
+        }
+        return Mono.<AnleggResource>empty().toFuture();
+    }
+}

--- a/src/main/java/no/fint/graphql/model/administrasjon/anlegg/AnleggResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/anlegg/AnleggResolver.java
@@ -1,0 +1,40 @@
+
+package no.fint.graphql.model.administrasjon.anlegg;
+
+import com.coxautodev.graphql.tools.GraphQLResolver;
+import graphql.schema.DataFetchingEnvironment;
+
+import no.fint.graphql.model.administrasjon.fullmakt.FullmaktService;
+
+
+import no.fint.model.resource.Link;
+import no.fint.model.resource.administrasjon.kodeverk.AnleggResource;
+import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+@Component("administrasjonAnleggResolver")
+public class AnleggResolver implements GraphQLResolver<AnleggResource> {
+
+    @Autowired
+    private FullmaktService fullmaktService;
+
+
+    public CompletionStage<List<FullmaktResource>> getFullmakt(AnleggResource anlegg, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(anlegg.getFullmakt()
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
+    }
+
+}
+

--- a/src/main/java/no/fint/graphql/model/administrasjon/anlegg/AnleggService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/anlegg/AnleggService.java
@@ -1,0 +1,35 @@
+
+package no.fint.graphql.model.administrasjon.anlegg;
+
+import graphql.schema.DataFetchingEnvironment;
+import no.fint.graphql.WebClientRequest;
+import no.fint.graphql.model.Endpoints;
+import no.fint.model.resource.administrasjon.kodeverk.AnleggResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service("administrasjonAnleggService")
+public class AnleggService {
+
+    @Autowired
+    private WebClientRequest webClientRequest;
+
+    @Autowired
+    private Endpoints endpoints;
+
+    public Mono<AnleggResource> getAnleggResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getAnleggResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/anlegg/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
+    }
+
+    public Mono<AnleggResource> getAnleggResource(String url, DataFetchingEnvironment dfe) {
+        return webClientRequest.get(url, AnleggResource.class, dfe);
+    }
+}
+

--- a/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.kodeverk.AnsvarResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonAnsvarQueryResolver")
 public class AnsvarQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class AnsvarQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private AnsvarService service;
 
-    public AnsvarResource getAnsvar(
+    public CompletionStage<AnsvarResource> getAnsvar(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getAnsvarResourceById("systemid", systemId, dfe);
+            return service.getAnsvarResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<AnsvarResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarResolver.java
@@ -42,7 +42,7 @@ public class AnsvarResolver implements GraphQLResolver<AnsvarResource> {
                 .map(Link::getHref)
                 .map(l -> ansvarService.getAnsvarResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarResolver.java
@@ -17,10 +17,11 @@ import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonAnsvarResolver")
 public class AnsvarResolver implements GraphQLResolver<AnsvarResource> {
@@ -35,40 +36,44 @@ public class AnsvarResolver implements GraphQLResolver<AnsvarResource> {
     private FullmaktService fullmaktService;
 
 
-    public AnsvarResource getOverordnet(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
-        return ansvar.getOverordnet()
+    public CompletionStage<AnsvarResource> getOverordnet(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(ansvar.getOverordnet()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> ansvarService.getAnsvarResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> ansvarService.getAnsvarResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public List<AnsvarResource> getUnderordnet(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
-        return ansvar.getUnderordnet()
+    public CompletionStage<List<AnsvarResource>> getUnderordnet(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(ansvar.getUnderordnet()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> ansvarService.getAnsvarResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> ansvarService.getAnsvarResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<OrganisasjonselementResource> getOrganisasjonselement(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
-        return ansvar.getOrganisasjonselement()
+    public CompletionStage<List<OrganisasjonselementResource>> getOrganisasjonselement(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(ansvar.getOrganisasjonselement()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<FullmaktResource> getFullmakt(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
-        return ansvar.getFullmakt()
+    public CompletionStage<List<FullmaktResource>> getFullmakt(AnsvarResource ansvar, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(ansvar.getFullmakt()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> fullmaktService.getFullmaktResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/ansvar/AnsvarService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.AnsvarResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonAnsvarService")
 public class AnsvarService {
@@ -17,7 +18,7 @@ public class AnsvarService {
     @Autowired
     private Endpoints endpoints;
 
-    public AnsvarResource getAnsvarResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<AnsvarResource> getAnsvarResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getAnsvarResource(
             endpoints.getAdministrasjonKodeverk() 
                 + "/ansvar/" 
@@ -27,7 +28,7 @@ public class AnsvarService {
             dfe);
     }
 
-    public AnsvarResource getAnsvarResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<AnsvarResource> getAnsvarResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, AnsvarResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.personal.ArbeidsforholdResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonArbeidsforholdQueryResolver")
 public class ArbeidsforholdQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class ArbeidsforholdQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ArbeidsforholdService service;
 
-    public ArbeidsforholdResource getArbeidsforhold(
+    public CompletionStage<ArbeidsforholdResource> getArbeidsforhold(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getArbeidsforholdResourceById("systemid", systemId, dfe);
+            return service.getArbeidsforholdResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<ArbeidsforholdResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdResolver.java
@@ -35,10 +35,11 @@ import no.fint.model.resource.utdanning.elev.UndervisningsforholdResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonArbeidsforholdResolver")
 public class ArbeidsforholdResolver implements GraphQLResolver<ArbeidsforholdResource> {
@@ -80,121 +81,134 @@ public class ArbeidsforholdResolver implements GraphQLResolver<ArbeidsforholdRes
     private UndervisningsforholdService undervisningsforholdService;
 
 
-    public AnsvarResource getAnsvar(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return arbeidsforhold.getAnsvar()
+    public CompletionStage<AnsvarResource> getAnsvar(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arbeidsforhold.getAnsvar()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> ansvarService.getAnsvarResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> ansvarService.getAnsvarResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public ArbeidsforholdstypeResource getArbeidsforholdstype(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return arbeidsforhold.getArbeidsforholdstype()
+    public CompletionStage<ArbeidsforholdstypeResource> getArbeidsforholdstype(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arbeidsforhold.getArbeidsforholdstype()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> arbeidsforholdstypeService.getArbeidsforholdstypeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> arbeidsforholdstypeService.getArbeidsforholdstypeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public ArtResource getArt(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return arbeidsforhold.getArt()
+    public CompletionStage<ArtResource> getArt(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arbeidsforhold.getArt()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> artService.getArtResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> artService.getArtResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public FunksjonResource getFunksjon(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return arbeidsforhold.getFunksjon()
+    public CompletionStage<FunksjonResource> getFunksjon(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arbeidsforhold.getFunksjon()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> funksjonService.getFunksjonResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> funksjonService.getFunksjonResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public StillingskodeResource getStillingskode(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return arbeidsforhold.getStillingskode()
+    public CompletionStage<StillingskodeResource> getStillingskode(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arbeidsforhold.getStillingskode()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> stillingskodeService.getStillingskodeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> stillingskodeService.getStillingskodeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public UketimetallResource getTimerPerUke(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return arbeidsforhold.getTimerPerUke()
+    public CompletionStage<UketimetallResource> getTimerPerUke(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arbeidsforhold.getTimerPerUke()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> uketimetallService.getUketimetallResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> uketimetallService.getUketimetallResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public OrganisasjonselementResource getArbeidssted(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return arbeidsforhold.getArbeidssted()
+    public CompletionStage<OrganisasjonselementResource> getArbeidssted(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arbeidsforhold.getArbeidssted()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public PersonalressursResource getPersonalleder(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return arbeidsforhold.getPersonalleder()
+    public CompletionStage<PersonalressursResource> getPersonalleder(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arbeidsforhold.getPersonalleder()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public List<FastlonnResource> getFastlonn(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return arbeidsforhold.getFastlonn()
+    public CompletionStage<List<FastlonnResource>> getFastlonn(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arbeidsforhold.getFastlonn()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> fastlonnService.getFastlonnResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> fastlonnService.getFastlonnResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<FasttilleggResource> getFasttillegg(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return arbeidsforhold.getFasttillegg()
+    public CompletionStage<List<FasttilleggResource>> getFasttillegg(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arbeidsforhold.getFasttillegg()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> fasttilleggService.getFasttilleggResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> fasttilleggService.getFasttilleggResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<VariabellonnResource> getVariabellonn(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return arbeidsforhold.getVariabellonn()
+    public CompletionStage<List<VariabellonnResource>> getVariabellonn(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arbeidsforhold.getVariabellonn()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> variabellonnService.getVariabellonnResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> variabellonnService.getVariabellonnResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public PersonalressursResource getPersonalressurs(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return arbeidsforhold.getPersonalressurs()
+    public CompletionStage<PersonalressursResource> getPersonalressurs(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arbeidsforhold.getPersonalressurs()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public UndervisningsforholdResource getUndervisningsforhold(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
-        return arbeidsforhold.getUndervisningsforhold()
+    public CompletionStage<UndervisningsforholdResource> getUndervisningsforhold(ArbeidsforholdResource arbeidsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arbeidsforhold.getUndervisningsforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdResolver.java
@@ -87,7 +87,7 @@ public class ArbeidsforholdResolver implements GraphQLResolver<ArbeidsforholdRes
                 .map(Link::getHref)
                 .map(l -> ansvarService.getAnsvarResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -97,7 +97,7 @@ public class ArbeidsforholdResolver implements GraphQLResolver<ArbeidsforholdRes
                 .map(Link::getHref)
                 .map(l -> arbeidsforholdstypeService.getArbeidsforholdstypeResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -107,7 +107,7 @@ public class ArbeidsforholdResolver implements GraphQLResolver<ArbeidsforholdRes
                 .map(Link::getHref)
                 .map(l -> artService.getArtResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -117,7 +117,7 @@ public class ArbeidsforholdResolver implements GraphQLResolver<ArbeidsforholdRes
                 .map(Link::getHref)
                 .map(l -> funksjonService.getFunksjonResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -127,7 +127,7 @@ public class ArbeidsforholdResolver implements GraphQLResolver<ArbeidsforholdRes
                 .map(Link::getHref)
                 .map(l -> stillingskodeService.getStillingskodeResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -137,7 +137,7 @@ public class ArbeidsforholdResolver implements GraphQLResolver<ArbeidsforholdRes
                 .map(Link::getHref)
                 .map(l -> uketimetallService.getUketimetallResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -147,7 +147,7 @@ public class ArbeidsforholdResolver implements GraphQLResolver<ArbeidsforholdRes
                 .map(Link::getHref)
                 .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -157,7 +157,7 @@ public class ArbeidsforholdResolver implements GraphQLResolver<ArbeidsforholdRes
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -197,7 +197,7 @@ public class ArbeidsforholdResolver implements GraphQLResolver<ArbeidsforholdRes
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -207,7 +207,7 @@ public class ArbeidsforholdResolver implements GraphQLResolver<ArbeidsforholdRes
                 .map(Link::getHref)
                 .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforhold/ArbeidsforholdService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.personal.ArbeidsforholdResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonArbeidsforholdService")
 public class ArbeidsforholdService {
@@ -17,7 +18,7 @@ public class ArbeidsforholdService {
     @Autowired
     private Endpoints endpoints;
 
-    public ArbeidsforholdResource getArbeidsforholdResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<ArbeidsforholdResource> getArbeidsforholdResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getArbeidsforholdResource(
             endpoints.getAdministrasjonPersonal() 
                 + "/arbeidsforhold/" 
@@ -27,7 +28,7 @@ public class ArbeidsforholdService {
             dfe);
     }
 
-    public ArbeidsforholdResource getArbeidsforholdResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<ArbeidsforholdResource> getArbeidsforholdResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, ArbeidsforholdResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforholdstype/ArbeidsforholdstypeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforholdstype/ArbeidsforholdstypeQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.kodeverk.ArbeidsforholdstypeResourc
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonArbeidsforholdstypeQueryResolver")
 public class ArbeidsforholdstypeQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class ArbeidsforholdstypeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ArbeidsforholdstypeService service;
 
-    public ArbeidsforholdstypeResource getArbeidsforholdstype(
+    public CompletionStage<ArbeidsforholdstypeResource> getArbeidsforholdstype(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getArbeidsforholdstypeResourceById("systemid", systemId, dfe);
+            return service.getArbeidsforholdstypeResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<ArbeidsforholdstypeResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforholdstype/ArbeidsforholdstypeResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforholdstype/ArbeidsforholdstypeResolver.java
@@ -32,7 +32,7 @@ public class ArbeidsforholdstypeResolver implements GraphQLResolver<Arbeidsforho
                 .map(Link::getHref)
                 .map(l -> arbeidsforholdstypeService.getArbeidsforholdstypeResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforholdstype/ArbeidsforholdstypeService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/arbeidsforholdstype/ArbeidsforholdstypeService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.ArbeidsforholdstypeResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonArbeidsforholdstypeService")
 public class ArbeidsforholdstypeService {
@@ -17,7 +18,7 @@ public class ArbeidsforholdstypeService {
     @Autowired
     private Endpoints endpoints;
 
-    public ArbeidsforholdstypeResource getArbeidsforholdstypeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<ArbeidsforholdstypeResource> getArbeidsforholdstypeResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getArbeidsforholdstypeResource(
             endpoints.getAdministrasjonKodeverk() 
                 + "/arbeidsforholdstype/" 
@@ -27,7 +28,7 @@ public class ArbeidsforholdstypeService {
             dfe);
     }
 
-    public ArbeidsforholdstypeResource getArbeidsforholdstypeResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<ArbeidsforholdstypeResource> getArbeidsforholdstypeResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, ArbeidsforholdstypeResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/art/ArtQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/art/ArtQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.kodeverk.ArtResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonArtQueryResolver")
 public class ArtQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class ArtQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ArtService service;
 
-    public ArtResource getArt(
+    public CompletionStage<ArtResource> getArt(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getArtResourceById("systemid", systemId, dfe);
+            return service.getArtResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<ArtResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/art/ArtResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/art/ArtResolver.java
@@ -13,10 +13,11 @@ import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonArtResolver")
 public class ArtResolver implements GraphQLResolver<ArtResource> {
@@ -25,13 +26,14 @@ public class ArtResolver implements GraphQLResolver<ArtResource> {
     private FullmaktService fullmaktService;
 
 
-    public List<FullmaktResource> getFullmakt(ArtResource art, DataFetchingEnvironment dfe) {
-        return art.getFullmakt()
+    public CompletionStage<List<FullmaktResource>> getFullmakt(ArtResource art, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(art.getFullmakt()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> fullmaktService.getFullmaktResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/art/ArtService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/art/ArtService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.ArtResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonArtService")
 public class ArtService {
@@ -17,7 +18,7 @@ public class ArtService {
     @Autowired
     private Endpoints endpoints;
 
-    public ArtResource getArtResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<ArtResource> getArtResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getArtResource(
             endpoints.getAdministrasjonKodeverk() 
                 + "/art/" 
@@ -27,7 +28,7 @@ public class ArtService {
             dfe);
     }
 
-    public ArtResource getArtResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<ArtResource> getArtResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, ArtResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/diverse/DiverseQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/diverse/DiverseQueryResolver.java
@@ -1,0 +1,28 @@
+
+package no.fint.graphql.model.administrasjon.diverse;
+
+import com.coxautodev.graphql.tools.GraphQLQueryResolver;
+import graphql.schema.DataFetchingEnvironment;
+import no.fint.model.resource.administrasjon.kodeverk.DiverseResource;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
+
+@Component("administrasjonDiverseQueryResolver")
+public class DiverseQueryResolver implements GraphQLQueryResolver {
+
+    @Autowired
+    private DiverseService service;
+
+    public CompletionStage<DiverseResource> getDiverse(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getDiverseResourceById("systemid", systemId, dfe).toFuture();
+        }
+        return Mono.<DiverseResource>empty().toFuture();
+    }
+}

--- a/src/main/java/no/fint/graphql/model/administrasjon/diverse/DiverseResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/diverse/DiverseResolver.java
@@ -1,0 +1,40 @@
+
+package no.fint.graphql.model.administrasjon.diverse;
+
+import com.coxautodev.graphql.tools.GraphQLResolver;
+import graphql.schema.DataFetchingEnvironment;
+
+import no.fint.graphql.model.administrasjon.fullmakt.FullmaktService;
+
+
+import no.fint.model.resource.Link;
+import no.fint.model.resource.administrasjon.kodeverk.DiverseResource;
+import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+@Component("administrasjonDiverseResolver")
+public class DiverseResolver implements GraphQLResolver<DiverseResource> {
+
+    @Autowired
+    private FullmaktService fullmaktService;
+
+
+    public CompletionStage<List<FullmaktResource>> getFullmakt(DiverseResource diverse, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(diverse.getFullmakt()
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
+    }
+
+}
+

--- a/src/main/java/no/fint/graphql/model/administrasjon/diverse/DiverseService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/diverse/DiverseService.java
@@ -1,0 +1,35 @@
+
+package no.fint.graphql.model.administrasjon.diverse;
+
+import graphql.schema.DataFetchingEnvironment;
+import no.fint.graphql.WebClientRequest;
+import no.fint.graphql.model.Endpoints;
+import no.fint.model.resource.administrasjon.kodeverk.DiverseResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service("administrasjonDiverseService")
+public class DiverseService {
+
+    @Autowired
+    private WebClientRequest webClientRequest;
+
+    @Autowired
+    private Endpoints endpoints;
+
+    public Mono<DiverseResource> getDiverseResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getDiverseResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/diverse/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
+    }
+
+    public Mono<DiverseResource> getDiverseResource(String url, DataFetchingEnvironment dfe) {
+        return webClientRequest.get(url, DiverseResource.class, dfe);
+    }
+}
+

--- a/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.personal.FastlonnResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonFastlonnQueryResolver")
 public class FastlonnQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,16 @@ public class FastlonnQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private FastlonnService service;
 
-    public FastlonnResource getFastlonn(
+    public CompletionStage<FastlonnResource> getFastlonn(
+            String kildesystemId,
             String systemId,
             DataFetchingEnvironment dfe) {
-        if (StringUtils.isNotEmpty(systemId)) {
-            return service.getFastlonnResourceById("systemid", systemId, dfe);
+        if (StringUtils.isNotEmpty(kildesystemId)) {
+            return service.getFastlonnResourceById("kildesystemid", kildesystemId, dfe).toFuture();
         }
-        return null;
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getFastlonnResourceById("systemid", systemId, dfe).toFuture();
+        }
+        return Mono.<FastlonnResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnResolver.java
@@ -17,10 +17,11 @@ import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonFastlonnResolver")
 public class FastlonnResolver implements GraphQLResolver<FastlonnResource> {
@@ -35,49 +36,54 @@ public class FastlonnResolver implements GraphQLResolver<FastlonnResource> {
     private PersonalressursService personalressursService;
 
 
-    public LonnsartResource getLonnsart(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
-        return fastlonn.getLonnsart()
+    public CompletionStage<LonnsartResource> getLonnsart(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fastlonn.getLonnsart()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> lonnsartService.getLonnsartResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> lonnsartService.getLonnsartResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public ArbeidsforholdResource getArbeidsforhold(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
-        return fastlonn.getArbeidsforhold()
+    public CompletionStage<ArbeidsforholdResource> getArbeidsforhold(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fastlonn.getArbeidsforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public PersonalressursResource getAnviser(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
-        return fastlonn.getAnviser()
+    public CompletionStage<PersonalressursResource> getAnviser(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fastlonn.getAnviser()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public PersonalressursResource getKonterer(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
-        return fastlonn.getKonterer()
+    public CompletionStage<PersonalressursResource> getKonterer(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fastlonn.getKonterer()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public PersonalressursResource getAttestant(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
-        return fastlonn.getAttestant()
+    public CompletionStage<PersonalressursResource> getAttestant(FastlonnResource fastlonn, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fastlonn.getAttestant()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnResolver.java
@@ -42,7 +42,7 @@ public class FastlonnResolver implements GraphQLResolver<FastlonnResource> {
                 .map(Link::getHref)
                 .map(l -> lonnsartService.getLonnsartResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -52,7 +52,7 @@ public class FastlonnResolver implements GraphQLResolver<FastlonnResource> {
                 .map(Link::getHref)
                 .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -62,7 +62,7 @@ public class FastlonnResolver implements GraphQLResolver<FastlonnResource> {
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -72,7 +72,7 @@ public class FastlonnResolver implements GraphQLResolver<FastlonnResource> {
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -82,7 +82,7 @@ public class FastlonnResolver implements GraphQLResolver<FastlonnResource> {
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fastlonn/FastlonnService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.personal.FastlonnResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonFastlonnService")
 public class FastlonnService {
@@ -17,7 +18,7 @@ public class FastlonnService {
     @Autowired
     private Endpoints endpoints;
 
-    public FastlonnResource getFastlonnResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<FastlonnResource> getFastlonnResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getFastlonnResource(
             endpoints.getAdministrasjonPersonal() 
                 + "/fastlonn/" 
@@ -27,7 +28,7 @@ public class FastlonnService {
             dfe);
     }
 
-    public FastlonnResource getFastlonnResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<FastlonnResource> getFastlonnResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, FastlonnResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.personal.FasttilleggResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonFasttilleggQueryResolver")
 public class FasttilleggQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,16 @@ public class FasttilleggQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private FasttilleggService service;
 
-    public FasttilleggResource getFasttillegg(
+    public CompletionStage<FasttilleggResource> getFasttillegg(
+            String kildesystemId,
             String systemId,
             DataFetchingEnvironment dfe) {
-        if (StringUtils.isNotEmpty(systemId)) {
-            return service.getFasttilleggResourceById("systemid", systemId, dfe);
+        if (StringUtils.isNotEmpty(kildesystemId)) {
+            return service.getFasttilleggResourceById("kildesystemid", kildesystemId, dfe).toFuture();
         }
-        return null;
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getFasttilleggResourceById("systemid", systemId, dfe).toFuture();
+        }
+        return Mono.<FasttilleggResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggResolver.java
@@ -17,10 +17,11 @@ import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonFasttilleggResolver")
 public class FasttilleggResolver implements GraphQLResolver<FasttilleggResource> {
@@ -35,49 +36,54 @@ public class FasttilleggResolver implements GraphQLResolver<FasttilleggResource>
     private PersonalressursService personalressursService;
 
 
-    public LonnsartResource getLonnsart(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
-        return fasttillegg.getLonnsart()
+    public CompletionStage<LonnsartResource> getLonnsart(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fasttillegg.getLonnsart()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> lonnsartService.getLonnsartResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> lonnsartService.getLonnsartResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public ArbeidsforholdResource getArbeidsforhold(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
-        return fasttillegg.getArbeidsforhold()
+    public CompletionStage<ArbeidsforholdResource> getArbeidsforhold(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fasttillegg.getArbeidsforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public PersonalressursResource getAnviser(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
-        return fasttillegg.getAnviser()
+    public CompletionStage<PersonalressursResource> getAnviser(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fasttillegg.getAnviser()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public PersonalressursResource getKonterer(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
-        return fasttillegg.getKonterer()
+    public CompletionStage<PersonalressursResource> getKonterer(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fasttillegg.getKonterer()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public PersonalressursResource getAttestant(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
-        return fasttillegg.getAttestant()
+    public CompletionStage<PersonalressursResource> getAttestant(FasttilleggResource fasttillegg, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fasttillegg.getAttestant()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggResolver.java
@@ -42,7 +42,7 @@ public class FasttilleggResolver implements GraphQLResolver<FasttilleggResource>
                 .map(Link::getHref)
                 .map(l -> lonnsartService.getLonnsartResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -52,7 +52,7 @@ public class FasttilleggResolver implements GraphQLResolver<FasttilleggResource>
                 .map(Link::getHref)
                 .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -62,7 +62,7 @@ public class FasttilleggResolver implements GraphQLResolver<FasttilleggResource>
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -72,7 +72,7 @@ public class FasttilleggResolver implements GraphQLResolver<FasttilleggResource>
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -82,7 +82,7 @@ public class FasttilleggResolver implements GraphQLResolver<FasttilleggResource>
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fasttillegg/FasttilleggService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.personal.FasttilleggResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonFasttilleggService")
 public class FasttilleggService {
@@ -17,7 +18,7 @@ public class FasttilleggService {
     @Autowired
     private Endpoints endpoints;
 
-    public FasttilleggResource getFasttilleggResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<FasttilleggResource> getFasttilleggResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getFasttilleggResource(
             endpoints.getAdministrasjonPersonal() 
                 + "/fasttillegg/" 
@@ -27,7 +28,7 @@ public class FasttilleggService {
             dfe);
     }
 
-    public FasttilleggResource getFasttilleggResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<FasttilleggResource> getFasttilleggResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, FasttilleggResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonFullmaktQueryResolver")
 public class FullmaktQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class FullmaktQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private FullmaktService service;
 
-    public FullmaktResource getFullmakt(
+    public CompletionStage<FullmaktResource> getFullmakt(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getFullmaktResourceById("systemid", systemId, dfe);
+            return service.getFullmaktResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<FullmaktResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktResolver.java
@@ -15,10 +15,11 @@ import no.fint.model.resource.administrasjon.fullmakt.RolleResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonFullmaktResolver")
 public class FullmaktResolver implements GraphQLResolver<FullmaktResource> {
@@ -30,31 +31,34 @@ public class FullmaktResolver implements GraphQLResolver<FullmaktResource> {
     private RolleService rolleService;
 
 
-    public PersonalressursResource getStedfortreder(FullmaktResource fullmakt, DataFetchingEnvironment dfe) {
-        return fullmakt.getStedfortreder()
+    public CompletionStage<PersonalressursResource> getStedfortreder(FullmaktResource fullmakt, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fullmakt.getStedfortreder()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public PersonalressursResource getFullmektig(FullmaktResource fullmakt, DataFetchingEnvironment dfe) {
-        return fullmakt.getFullmektig()
+    public CompletionStage<PersonalressursResource> getFullmektig(FullmaktResource fullmakt, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fullmakt.getFullmektig()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public RolleResource getRolle(FullmaktResource fullmakt, DataFetchingEnvironment dfe) {
-        return fullmakt.getRolle()
+    public CompletionStage<RolleResource> getRolle(FullmaktResource fullmakt, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fullmakt.getRolle()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> rolleService.getRolleResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> rolleService.getRolleResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktResolver.java
@@ -37,7 +37,7 @@ public class FullmaktResolver implements GraphQLResolver<FullmaktResource> {
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -47,7 +47,7 @@ public class FullmaktResolver implements GraphQLResolver<FullmaktResource> {
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -57,7 +57,7 @@ public class FullmaktResolver implements GraphQLResolver<FullmaktResource> {
                 .map(Link::getHref)
                 .map(l -> rolleService.getRolleResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/fullmakt/FullmaktService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonFullmaktService")
 public class FullmaktService {
@@ -17,7 +18,7 @@ public class FullmaktService {
     @Autowired
     private Endpoints endpoints;
 
-    public FullmaktResource getFullmaktResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<FullmaktResource> getFullmaktResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getFullmaktResource(
             endpoints.getAdministrasjonFullmakt() 
                 + "/fullmakt/" 
@@ -27,7 +28,7 @@ public class FullmaktService {
             dfe);
     }
 
-    public FullmaktResource getFullmaktResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<FullmaktResource> getFullmaktResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, FullmaktResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.kodeverk.FunksjonResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonFunksjonQueryResolver")
 public class FunksjonQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class FunksjonQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private FunksjonService service;
 
-    public FunksjonResource getFunksjon(
+    public CompletionStage<FunksjonResource> getFunksjon(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getFunksjonResourceById("systemid", systemId, dfe);
+            return service.getFunksjonResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<FunksjonResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonResolver.java
@@ -37,7 +37,7 @@ public class FunksjonResolver implements GraphQLResolver<FunksjonResource> {
                 .map(Link::getHref)
                 .map(l -> funksjonService.getFunksjonResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonResolver.java
@@ -15,10 +15,11 @@ import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonFunksjonResolver")
 public class FunksjonResolver implements GraphQLResolver<FunksjonResource> {
@@ -30,31 +31,34 @@ public class FunksjonResolver implements GraphQLResolver<FunksjonResource> {
     private FullmaktService fullmaktService;
 
 
-    public FunksjonResource getOverordnet(FunksjonResource funksjon, DataFetchingEnvironment dfe) {
-        return funksjon.getOverordnet()
+    public CompletionStage<FunksjonResource> getOverordnet(FunksjonResource funksjon, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(funksjon.getOverordnet()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> funksjonService.getFunksjonResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> funksjonService.getFunksjonResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public List<FunksjonResource> getUnderordnet(FunksjonResource funksjon, DataFetchingEnvironment dfe) {
-        return funksjon.getUnderordnet()
+    public CompletionStage<List<FunksjonResource>> getUnderordnet(FunksjonResource funksjon, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(funksjon.getUnderordnet()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> funksjonService.getFunksjonResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> funksjonService.getFunksjonResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<FullmaktResource> getFullmakt(FunksjonResource funksjon, DataFetchingEnvironment dfe) {
-        return funksjon.getFullmakt()
+    public CompletionStage<List<FullmaktResource>> getFullmakt(FunksjonResource funksjon, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(funksjon.getFullmakt()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> fullmaktService.getFullmaktResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/funksjon/FunksjonService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.FunksjonResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonFunksjonService")
 public class FunksjonService {
@@ -17,7 +18,7 @@ public class FunksjonService {
     @Autowired
     private Endpoints endpoints;
 
-    public FunksjonResource getFunksjonResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<FunksjonResource> getFunksjonResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getFunksjonResource(
             endpoints.getAdministrasjonKodeverk() 
                 + "/funksjon/" 
@@ -27,7 +28,7 @@ public class FunksjonService {
             dfe);
     }
 
-    public FunksjonResource getFunksjonResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<FunksjonResource> getFunksjonResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, FunksjonResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/kontostreng/KontostrengResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/kontostreng/KontostrengResolver.java
@@ -4,28 +4,49 @@ package no.fint.graphql.model.administrasjon.kontostreng;
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
 
+import no.fint.graphql.model.administrasjon.aktivitet.AktivitetService;
+import no.fint.graphql.model.administrasjon.anlegg.AnleggService;
 import no.fint.graphql.model.administrasjon.ansvar.AnsvarService;
 import no.fint.graphql.model.administrasjon.art.ArtService;
+import no.fint.graphql.model.administrasjon.diverse.DiverseService;
 import no.fint.graphql.model.administrasjon.funksjon.FunksjonService;
+import no.fint.graphql.model.administrasjon.kontrakt.KontraktService;
+import no.fint.graphql.model.administrasjon.lopenummer.LopenummerService;
+import no.fint.graphql.model.administrasjon.objekt.ObjektService;
 import no.fint.graphql.model.administrasjon.prosjekt.ProsjektService;
+import no.fint.graphql.model.administrasjon.ramme.RammeService;
 
 
 import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.kompleksedatatyper.KontostrengResource;
+import no.fint.model.resource.administrasjon.kodeverk.AktivitetResource;
+import no.fint.model.resource.administrasjon.kodeverk.AnleggResource;
 import no.fint.model.resource.administrasjon.kodeverk.AnsvarResource;
 import no.fint.model.resource.administrasjon.kodeverk.ArtResource;
+import no.fint.model.resource.administrasjon.kodeverk.DiverseResource;
 import no.fint.model.resource.administrasjon.kodeverk.FunksjonResource;
+import no.fint.model.resource.administrasjon.kodeverk.KontraktResource;
+import no.fint.model.resource.administrasjon.kodeverk.LopenummerResource;
+import no.fint.model.resource.administrasjon.kodeverk.ObjektResource;
 import no.fint.model.resource.administrasjon.kodeverk.ProsjektResource;
+import no.fint.model.resource.administrasjon.kodeverk.RammeResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonKontostrengResolver")
 public class KontostrengResolver implements GraphQLResolver<KontostrengResource> {
+
+    @Autowired
+    private AktivitetService aktivitetService;
+
+    @Autowired
+    private AnleggService anleggService;
 
     @Autowired
     private AnsvarService ansvarService;
@@ -34,46 +55,135 @@ public class KontostrengResolver implements GraphQLResolver<KontostrengResource>
     private ArtService artService;
 
     @Autowired
+    private DiverseService diverseService;
+
+    @Autowired
     private FunksjonService funksjonService;
+
+    @Autowired
+    private KontraktService kontraktService;
+
+    @Autowired
+    private LopenummerService lopenummerService;
+
+    @Autowired
+    private ObjektService objektService;
 
     @Autowired
     private ProsjektService prosjektService;
 
+    @Autowired
+    private RammeService rammeService;
 
-    public AnsvarResource getAnsvar(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
-        return kontostreng.getAnsvar()
+
+    public CompletionStage<AktivitetResource> getAktivitet(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontostreng.getAktivitet()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> ansvarService.getAnsvarResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> aktivitetService.getAktivitetResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public ArtResource getArt(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
-        return kontostreng.getArt()
+    public CompletionStage<AnleggResource> getAnlegg(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontostreng.getAnlegg()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> artService.getArtResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> anleggService.getAnleggResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public FunksjonResource getFunksjon(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
-        return kontostreng.getFunksjon()
+    public CompletionStage<AnsvarResource> getAnsvar(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontostreng.getAnsvar()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> funksjonService.getFunksjonResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> ansvarService.getAnsvarResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public ProsjektResource getProsjekt(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
-        return kontostreng.getProsjekt()
+    public CompletionStage<ArtResource> getArt(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontostreng.getArt()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> prosjektService.getProsjektResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> artService.getArtResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
+    }
+
+    public CompletionStage<DiverseResource> getDiverse(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontostreng.getDiverse()
+                .stream()
+                .map(Link::getHref)
+                .map(l -> diverseService.getDiverseResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
+    }
+
+    public CompletionStage<FunksjonResource> getFunksjon(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontostreng.getFunksjon()
+                .stream()
+                .map(Link::getHref)
+                .map(l -> funksjonService.getFunksjonResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
+    }
+
+    public CompletionStage<KontraktResource> getKontrakt(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontostreng.getKontrakt()
+                .stream()
+                .map(Link::getHref)
+                .map(l -> kontraktService.getKontraktResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
+    }
+
+    public CompletionStage<LopenummerResource> getLopenummer(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontostreng.getLopenummer()
+                .stream()
+                .map(Link::getHref)
+                .map(l -> lopenummerService.getLopenummerResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
+    }
+
+    public CompletionStage<ObjektResource> getObjekt(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontostreng.getObjekt()
+                .stream()
+                .map(Link::getHref)
+                .map(l -> objektService.getObjektResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
+    }
+
+    public CompletionStage<ProsjektResource> getProsjekt(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontostreng.getProsjekt()
+                .stream()
+                .map(Link::getHref)
+                .map(l -> prosjektService.getProsjektResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
+    }
+
+    public CompletionStage<RammeResource> getRamme(KontostrengResource kontostreng, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontostreng.getRamme()
+                .stream()
+                .map(Link::getHref)
+                .map(l -> rammeService.getRammeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/kontostreng/KontostrengResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/kontostreng/KontostrengResolver.java
@@ -82,7 +82,7 @@ public class KontostrengResolver implements GraphQLResolver<KontostrengResource>
                 .map(Link::getHref)
                 .map(l -> aktivitetService.getAktivitetResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -92,7 +92,7 @@ public class KontostrengResolver implements GraphQLResolver<KontostrengResource>
                 .map(Link::getHref)
                 .map(l -> anleggService.getAnleggResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -102,7 +102,7 @@ public class KontostrengResolver implements GraphQLResolver<KontostrengResource>
                 .map(Link::getHref)
                 .map(l -> ansvarService.getAnsvarResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -112,7 +112,7 @@ public class KontostrengResolver implements GraphQLResolver<KontostrengResource>
                 .map(Link::getHref)
                 .map(l -> artService.getArtResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -122,7 +122,7 @@ public class KontostrengResolver implements GraphQLResolver<KontostrengResource>
                 .map(Link::getHref)
                 .map(l -> diverseService.getDiverseResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -132,7 +132,7 @@ public class KontostrengResolver implements GraphQLResolver<KontostrengResource>
                 .map(Link::getHref)
                 .map(l -> funksjonService.getFunksjonResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -142,7 +142,7 @@ public class KontostrengResolver implements GraphQLResolver<KontostrengResource>
                 .map(Link::getHref)
                 .map(l -> kontraktService.getKontraktResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -152,7 +152,7 @@ public class KontostrengResolver implements GraphQLResolver<KontostrengResource>
                 .map(Link::getHref)
                 .map(l -> lopenummerService.getLopenummerResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -162,7 +162,7 @@ public class KontostrengResolver implements GraphQLResolver<KontostrengResource>
                 .map(Link::getHref)
                 .map(l -> objektService.getObjektResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -172,7 +172,7 @@ public class KontostrengResolver implements GraphQLResolver<KontostrengResource>
                 .map(Link::getHref)
                 .map(l -> prosjektService.getProsjektResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -182,7 +182,7 @@ public class KontostrengResolver implements GraphQLResolver<KontostrengResource>
                 .map(Link::getHref)
                 .map(l -> rammeService.getRammeResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/administrasjon/kontrakt/KontraktQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/kontrakt/KontraktQueryResolver.java
@@ -1,0 +1,28 @@
+
+package no.fint.graphql.model.administrasjon.kontrakt;
+
+import com.coxautodev.graphql.tools.GraphQLQueryResolver;
+import graphql.schema.DataFetchingEnvironment;
+import no.fint.model.resource.administrasjon.kodeverk.KontraktResource;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
+
+@Component("administrasjonKontraktQueryResolver")
+public class KontraktQueryResolver implements GraphQLQueryResolver {
+
+    @Autowired
+    private KontraktService service;
+
+    public CompletionStage<KontraktResource> getKontrakt(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getKontraktResourceById("systemid", systemId, dfe).toFuture();
+        }
+        return Mono.<KontraktResource>empty().toFuture();
+    }
+}

--- a/src/main/java/no/fint/graphql/model/administrasjon/kontrakt/KontraktResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/kontrakt/KontraktResolver.java
@@ -1,0 +1,40 @@
+
+package no.fint.graphql.model.administrasjon.kontrakt;
+
+import com.coxautodev.graphql.tools.GraphQLResolver;
+import graphql.schema.DataFetchingEnvironment;
+
+import no.fint.graphql.model.administrasjon.fullmakt.FullmaktService;
+
+
+import no.fint.model.resource.Link;
+import no.fint.model.resource.administrasjon.kodeverk.KontraktResource;
+import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+@Component("administrasjonKontraktResolver")
+public class KontraktResolver implements GraphQLResolver<KontraktResource> {
+
+    @Autowired
+    private FullmaktService fullmaktService;
+
+
+    public CompletionStage<List<FullmaktResource>> getFullmakt(KontraktResource kontrakt, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontrakt.getFullmakt()
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
+    }
+
+}
+

--- a/src/main/java/no/fint/graphql/model/administrasjon/kontrakt/KontraktService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/kontrakt/KontraktService.java
@@ -1,0 +1,35 @@
+
+package no.fint.graphql.model.administrasjon.kontrakt;
+
+import graphql.schema.DataFetchingEnvironment;
+import no.fint.graphql.WebClientRequest;
+import no.fint.graphql.model.Endpoints;
+import no.fint.model.resource.administrasjon.kodeverk.KontraktResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service("administrasjonKontraktService")
+public class KontraktService {
+
+    @Autowired
+    private WebClientRequest webClientRequest;
+
+    @Autowired
+    private Endpoints endpoints;
+
+    public Mono<KontraktResource> getKontraktResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getKontraktResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/kontrakt/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
+    }
+
+    public Mono<KontraktResource> getKontraktResource(String url, DataFetchingEnvironment dfe) {
+        return webClientRequest.get(url, KontraktResource.class, dfe);
+    }
+}
+

--- a/src/main/java/no/fint/graphql/model/administrasjon/lonnsart/LonnsartQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/lonnsart/LonnsartQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.kodeverk.LonnsartResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonLonnsartQueryResolver")
 public class LonnsartQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class LonnsartQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private LonnsartService service;
 
-    public LonnsartResource getLonnsart(
+    public CompletionStage<LonnsartResource> getLonnsart(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getLonnsartResourceById("systemid", systemId, dfe);
+            return service.getLonnsartResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<LonnsartResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/lonnsart/LonnsartResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/lonnsart/LonnsartResolver.java
@@ -32,7 +32,7 @@ public class LonnsartResolver implements GraphQLResolver<LonnsartResource> {
                 .map(Link::getHref)
                 .map(l -> artService.getArtResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/administrasjon/lonnsart/LonnsartResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/lonnsart/LonnsartResolver.java
@@ -13,10 +13,11 @@ import no.fint.model.resource.administrasjon.kodeverk.ArtResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonLonnsartResolver")
 public class LonnsartResolver implements GraphQLResolver<LonnsartResource> {
@@ -25,13 +26,14 @@ public class LonnsartResolver implements GraphQLResolver<LonnsartResource> {
     private ArtService artService;
 
 
-    public ArtResource getArt(LonnsartResource lonnsart, DataFetchingEnvironment dfe) {
-        return lonnsart.getArt()
+    public CompletionStage<ArtResource> getArt(LonnsartResource lonnsart, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(lonnsart.getArt()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> artService.getArtResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> artService.getArtResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/lonnsart/LonnsartService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/lonnsart/LonnsartService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.LonnsartResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonLonnsartService")
 public class LonnsartService {
@@ -17,7 +18,7 @@ public class LonnsartService {
     @Autowired
     private Endpoints endpoints;
 
-    public LonnsartResource getLonnsartResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<LonnsartResource> getLonnsartResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getLonnsartResource(
             endpoints.getAdministrasjonKodeverk() 
                 + "/lonnsart/" 
@@ -27,7 +28,7 @@ public class LonnsartService {
             dfe);
     }
 
-    public LonnsartResource getLonnsartResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<LonnsartResource> getLonnsartResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, LonnsartResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/lopenummer/LopenummerQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/lopenummer/LopenummerQueryResolver.java
@@ -1,0 +1,28 @@
+
+package no.fint.graphql.model.administrasjon.lopenummer;
+
+import com.coxautodev.graphql.tools.GraphQLQueryResolver;
+import graphql.schema.DataFetchingEnvironment;
+import no.fint.model.resource.administrasjon.kodeverk.LopenummerResource;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
+
+@Component("administrasjonLopenummerQueryResolver")
+public class LopenummerQueryResolver implements GraphQLQueryResolver {
+
+    @Autowired
+    private LopenummerService service;
+
+    public CompletionStage<LopenummerResource> getLopenummer(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getLopenummerResourceById("systemid", systemId, dfe).toFuture();
+        }
+        return Mono.<LopenummerResource>empty().toFuture();
+    }
+}

--- a/src/main/java/no/fint/graphql/model/administrasjon/lopenummer/LopenummerResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/lopenummer/LopenummerResolver.java
@@ -1,0 +1,40 @@
+
+package no.fint.graphql.model.administrasjon.lopenummer;
+
+import com.coxautodev.graphql.tools.GraphQLResolver;
+import graphql.schema.DataFetchingEnvironment;
+
+import no.fint.graphql.model.administrasjon.fullmakt.FullmaktService;
+
+
+import no.fint.model.resource.Link;
+import no.fint.model.resource.administrasjon.kodeverk.LopenummerResource;
+import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+@Component("administrasjonLopenummerResolver")
+public class LopenummerResolver implements GraphQLResolver<LopenummerResource> {
+
+    @Autowired
+    private FullmaktService fullmaktService;
+
+
+    public CompletionStage<List<FullmaktResource>> getFullmakt(LopenummerResource lopenummer, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(lopenummer.getFullmakt()
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
+    }
+
+}
+

--- a/src/main/java/no/fint/graphql/model/administrasjon/lopenummer/LopenummerService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/lopenummer/LopenummerService.java
@@ -1,0 +1,35 @@
+
+package no.fint.graphql.model.administrasjon.lopenummer;
+
+import graphql.schema.DataFetchingEnvironment;
+import no.fint.graphql.WebClientRequest;
+import no.fint.graphql.model.Endpoints;
+import no.fint.model.resource.administrasjon.kodeverk.LopenummerResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service("administrasjonLopenummerService")
+public class LopenummerService {
+
+    @Autowired
+    private WebClientRequest webClientRequest;
+
+    @Autowired
+    private Endpoints endpoints;
+
+    public Mono<LopenummerResource> getLopenummerResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getLopenummerResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/lopenummer/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
+    }
+
+    public Mono<LopenummerResource> getLopenummerResource(String url, DataFetchingEnvironment dfe) {
+        return webClientRequest.get(url, LopenummerResource.class, dfe);
+    }
+}
+

--- a/src/main/java/no/fint/graphql/model/administrasjon/objekt/ObjektQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/objekt/ObjektQueryResolver.java
@@ -1,0 +1,28 @@
+
+package no.fint.graphql.model.administrasjon.objekt;
+
+import com.coxautodev.graphql.tools.GraphQLQueryResolver;
+import graphql.schema.DataFetchingEnvironment;
+import no.fint.model.resource.administrasjon.kodeverk.ObjektResource;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
+
+@Component("administrasjonObjektQueryResolver")
+public class ObjektQueryResolver implements GraphQLQueryResolver {
+
+    @Autowired
+    private ObjektService service;
+
+    public CompletionStage<ObjektResource> getObjekt(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getObjektResourceById("systemid", systemId, dfe).toFuture();
+        }
+        return Mono.<ObjektResource>empty().toFuture();
+    }
+}

--- a/src/main/java/no/fint/graphql/model/administrasjon/objekt/ObjektResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/objekt/ObjektResolver.java
@@ -1,0 +1,40 @@
+
+package no.fint.graphql.model.administrasjon.objekt;
+
+import com.coxautodev.graphql.tools.GraphQLResolver;
+import graphql.schema.DataFetchingEnvironment;
+
+import no.fint.graphql.model.administrasjon.fullmakt.FullmaktService;
+
+
+import no.fint.model.resource.Link;
+import no.fint.model.resource.administrasjon.kodeverk.ObjektResource;
+import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+@Component("administrasjonObjektResolver")
+public class ObjektResolver implements GraphQLResolver<ObjektResource> {
+
+    @Autowired
+    private FullmaktService fullmaktService;
+
+
+    public CompletionStage<List<FullmaktResource>> getFullmakt(ObjektResource objekt, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(objekt.getFullmakt()
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
+    }
+
+}
+

--- a/src/main/java/no/fint/graphql/model/administrasjon/objekt/ObjektService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/objekt/ObjektService.java
@@ -1,0 +1,35 @@
+
+package no.fint.graphql.model.administrasjon.objekt;
+
+import graphql.schema.DataFetchingEnvironment;
+import no.fint.graphql.WebClientRequest;
+import no.fint.graphql.model.Endpoints;
+import no.fint.model.resource.administrasjon.kodeverk.ObjektResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service("administrasjonObjektService")
+public class ObjektService {
+
+    @Autowired
+    private WebClientRequest webClientRequest;
+
+    @Autowired
+    private Endpoints endpoints;
+
+    public Mono<ObjektResource> getObjektResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getObjektResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/objekt/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
+    }
+
+    public Mono<ObjektResource> getObjektResource(String url, DataFetchingEnvironment dfe) {
+        return webClientRequest.get(url, ObjektResource.class, dfe);
+    }
+}
+

--- a/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.organisasjon.OrganisasjonselementRe
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonOrganisasjonselementQueryResolver")
 public class OrganisasjonselementQueryResolver implements GraphQLQueryResolver {
@@ -14,20 +17,20 @@ public class OrganisasjonselementQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private OrganisasjonselementService service;
 
-    public OrganisasjonselementResource getOrganisasjonselement(
+    public CompletionStage<OrganisasjonselementResource> getOrganisasjonselement(
             String organisasjonsId,
             String organisasjonsKode,
             String organisasjonsnummer,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(organisasjonsId)) {
-            return service.getOrganisasjonselementResourceById("organisasjonsid", organisasjonsId, dfe);
+            return service.getOrganisasjonselementResourceById("organisasjonsid", organisasjonsId, dfe).toFuture();
         }
         if (StringUtils.isNotEmpty(organisasjonsKode)) {
-            return service.getOrganisasjonselementResourceById("organisasjonskode", organisasjonsKode, dfe);
+            return service.getOrganisasjonselementResourceById("organisasjonskode", organisasjonsKode, dfe).toFuture();
         }
         if (StringUtils.isNotEmpty(organisasjonsnummer)) {
-            return service.getOrganisasjonselementResourceById("organisasjonsnummer", organisasjonsnummer, dfe);
+            return service.getOrganisasjonselementResourceById("organisasjonsnummer", organisasjonsnummer, dfe).toFuture();
         }
-        return null;
+        return Mono.<OrganisasjonselementResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementResolver.java
@@ -62,7 +62,7 @@ public class OrganisasjonselementResolver implements GraphQLResolver<Organisasjo
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -72,7 +72,7 @@ public class OrganisasjonselementResolver implements GraphQLResolver<Organisasjo
                 .map(Link::getHref)
                 .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -92,7 +92,7 @@ public class OrganisasjonselementResolver implements GraphQLResolver<Organisasjo
                 .map(Link::getHref)
                 .map(l -> skoleService.getSkoleResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementResolver.java
@@ -6,6 +6,7 @@ import graphql.schema.DataFetchingEnvironment;
 
 import no.fint.graphql.model.administrasjon.ansvar.AnsvarService;
 import no.fint.graphql.model.administrasjon.personalressurs.PersonalressursService;
+import no.fint.graphql.model.administrasjon.organisasjonselement.OrganisasjonselementService;
 import no.fint.graphql.model.utdanning.skole.SkoleService;
 import no.fint.graphql.model.administrasjon.arbeidsforhold.ArbeidsforholdService;
 
@@ -14,6 +15,7 @@ import no.fint.model.resource.Link;
 import no.fint.model.resource.administrasjon.organisasjon.OrganisasjonselementResource;
 import no.fint.model.resource.administrasjon.kodeverk.AnsvarResource;
 import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
+import no.fint.model.resource.administrasjon.organisasjon.OrganisasjonselementResource;
 import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
 import no.fint.model.resource.administrasjon.personal.ArbeidsforholdResource;
 
@@ -23,9 +25,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 @Component("administrasjonOrganisasjonselementResolver")
 public class OrganisasjonselementResolver implements GraphQLResolver<OrganisasjonselementResource> {
@@ -46,40 +46,44 @@ public class OrganisasjonselementResolver implements GraphQLResolver<Organisasjo
     private ArbeidsforholdService arbeidsforholdService;
 
 
-    public List<AnsvarResource> getAnsvar(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
-        return organisasjonselement.getAnsvar()
+    public CompletionStage<List<AnsvarResource>> getAnsvar(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(organisasjonselement.getAnsvar()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> ansvarService.getAnsvarResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> ansvarService.getAnsvarResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public PersonalressursResource getLeder(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
-        return organisasjonselement.getLeder()
+    public CompletionStage<PersonalressursResource> getLeder(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(organisasjonselement.getLeder()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public OrganisasjonselementResource getOverordnet(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
-        return organisasjonselement.getOverordnet()
+    public CompletionStage<OrganisasjonselementResource> getOverordnet(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(organisasjonselement.getOverordnet()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public List<OrganisasjonselementResource> getUnderordnet(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
-        return organisasjonselement.getUnderordnet()
+    public CompletionStage<List<OrganisasjonselementResource>> getUnderordnet(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(organisasjonselement.getUnderordnet()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
     public CompletionStage<SkoleResource> getSkole(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
@@ -92,13 +96,14 @@ public class OrganisasjonselementResolver implements GraphQLResolver<Organisasjo
                 .toFuture();
     }
 
-    public List<ArbeidsforholdResource> getArbeidsforhold(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
-        return organisasjonselement.getArbeidsforhold()
+    public CompletionStage<List<ArbeidsforholdResource>> getArbeidsforhold(OrganisasjonselementResource organisasjonselement, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(organisasjonselement.getArbeidsforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/organisasjonselement/OrganisasjonselementService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.organisasjon.OrganisasjonselementResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonOrganisasjonselementService")
 public class OrganisasjonselementService {
@@ -17,7 +18,7 @@ public class OrganisasjonselementService {
     @Autowired
     private Endpoints endpoints;
 
-    public OrganisasjonselementResource getOrganisasjonselementResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<OrganisasjonselementResource> getOrganisasjonselementResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getOrganisasjonselementResource(
             endpoints.getAdministrasjonOrganisasjon() 
                 + "/organisasjonselement/" 
@@ -27,7 +28,7 @@ public class OrganisasjonselementService {
             dfe);
     }
 
-    public OrganisasjonselementResource getOrganisasjonselementResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<OrganisasjonselementResource> getOrganisasjonselementResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, OrganisasjonselementResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonPersonalressursQueryResolver")
 public class PersonalressursQueryResolver implements GraphQLQueryResolver {
@@ -14,20 +17,20 @@ public class PersonalressursQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private PersonalressursService service;
 
-    public PersonalressursResource getPersonalressurs(
+    public CompletionStage<PersonalressursResource> getPersonalressurs(
             String ansattnummer,
             String brukernavn,
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(ansattnummer)) {
-            return service.getPersonalressursResourceById("ansattnummer", ansattnummer, dfe);
+            return service.getPersonalressursResourceById("ansattnummer", ansattnummer, dfe).toFuture();
         }
         if (StringUtils.isNotEmpty(brukernavn)) {
-            return service.getPersonalressursResourceById("brukernavn", brukernavn, dfe);
+            return service.getPersonalressursResourceById("brukernavn", brukernavn, dfe).toFuture();
         }
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getPersonalressursResourceById("systemid", systemId, dfe);
+            return service.getPersonalressursResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<PersonalressursResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursResolver.java
@@ -27,9 +27,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 @Component("administrasjonPersonalressursResolver")
 public class PersonalressursResolver implements GraphQLResolver<PersonalressursResource> {
@@ -53,22 +51,24 @@ public class PersonalressursResolver implements GraphQLResolver<PersonalressursR
     private SkoleressursService skoleressursService;
 
 
-    public PersonalressurskategoriResource getPersonalressurskategori(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
-        return personalressurs.getPersonalressurskategori()
+    public CompletionStage<PersonalressurskategoriResource> getPersonalressurskategori(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(personalressurs.getPersonalressurskategori()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressurskategoriService.getPersonalressurskategoriResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressurskategoriService.getPersonalressurskategoriResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public List<ArbeidsforholdResource> getArbeidsforhold(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
-        return personalressurs.getArbeidsforhold()
+    public CompletionStage<List<ArbeidsforholdResource>> getArbeidsforhold(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(personalressurs.getArbeidsforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
     public CompletionStage<PersonResource> getPerson(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
@@ -77,54 +77,58 @@ public class PersonalressursResolver implements GraphQLResolver<PersonalressursR
                 .map(Link::getHref)
                 .map(l -> personService.getPersonResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .filter(Objects::nonNull)
                 .singleOrEmpty()
                 .toFuture();
     }
 
-    public List<FullmaktResource> getStedfortreder(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
-        return personalressurs.getStedfortreder()
+    public CompletionStage<List<FullmaktResource>> getStedfortreder(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(personalressurs.getStedfortreder()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> fullmaktService.getFullmaktResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<FullmaktResource> getFullmakt(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
-        return personalressurs.getFullmakt()
+    public CompletionStage<List<FullmaktResource>> getFullmakt(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(personalressurs.getFullmakt()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> fullmaktService.getFullmaktResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<OrganisasjonselementResource> getLeder(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
-        return personalressurs.getLeder()
+    public CompletionStage<List<OrganisasjonselementResource>> getLeder(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(personalressurs.getLeder()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<ArbeidsforholdResource> getPersonalansvar(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
-        return personalressurs.getPersonalansvar()
+    public CompletionStage<List<ArbeidsforholdResource>> getPersonalansvar(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(personalressurs.getPersonalansvar()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public SkoleressursResource getSkoleressurs(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
-        return personalressurs.getSkoleressurs()
+    public CompletionStage<SkoleressursResource> getSkoleressurs(PersonalressursResource personalressurs, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(personalressurs.getSkoleressurs()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> skoleressursService.getSkoleressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> skoleressursService.getSkoleressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursResolver.java
@@ -57,7 +57,7 @@ public class PersonalressursResolver implements GraphQLResolver<PersonalressursR
                 .map(Link::getHref)
                 .map(l -> personalressurskategoriService.getPersonalressurskategoriResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -77,7 +77,7 @@ public class PersonalressursResolver implements GraphQLResolver<PersonalressursR
                 .map(Link::getHref)
                 .map(l -> personService.getPersonResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -127,7 +127,7 @@ public class PersonalressursResolver implements GraphQLResolver<PersonalressursR
                 .map(Link::getHref)
                 .map(l -> skoleressursService.getSkoleressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/personalressurs/PersonalressursService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonPersonalressursService")
 public class PersonalressursService {
@@ -17,7 +18,7 @@ public class PersonalressursService {
     @Autowired
     private Endpoints endpoints;
 
-    public PersonalressursResource getPersonalressursResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<PersonalressursResource> getPersonalressursResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getPersonalressursResource(
             endpoints.getAdministrasjonPersonal() 
                 + "/personalressurs/" 
@@ -27,7 +28,7 @@ public class PersonalressursService {
             dfe);
     }
 
-    public PersonalressursResource getPersonalressursResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<PersonalressursResource> getPersonalressursResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, PersonalressursResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/personalressurskategori/PersonalressurskategoriQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/personalressurskategori/PersonalressurskategoriQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.kodeverk.PersonalressurskategoriRes
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonPersonalressurskategoriQueryResolver")
 public class PersonalressurskategoriQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class PersonalressurskategoriQueryResolver implements GraphQLQueryResolve
     @Autowired
     private PersonalressurskategoriService service;
 
-    public PersonalressurskategoriResource getPersonalressurskategori(
+    public CompletionStage<PersonalressurskategoriResource> getPersonalressurskategori(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getPersonalressurskategoriResourceById("systemid", systemId, dfe);
+            return service.getPersonalressurskategoriResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<PersonalressurskategoriResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/personalressurskategori/PersonalressurskategoriService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/personalressurskategori/PersonalressurskategoriService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.PersonalressurskategoriResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonPersonalressurskategoriService")
 public class PersonalressurskategoriService {
@@ -17,7 +18,7 @@ public class PersonalressurskategoriService {
     @Autowired
     private Endpoints endpoints;
 
-    public PersonalressurskategoriResource getPersonalressurskategoriResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<PersonalressurskategoriResource> getPersonalressurskategoriResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getPersonalressurskategoriResource(
             endpoints.getAdministrasjonKodeverk() 
                 + "/personalressurskategori/" 
@@ -27,7 +28,7 @@ public class PersonalressurskategoriService {
             dfe);
     }
 
-    public PersonalressurskategoriResource getPersonalressurskategoriResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<PersonalressurskategoriResource> getPersonalressurskategoriResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, PersonalressurskategoriResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/prosjekt/ProsjektQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/prosjekt/ProsjektQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.kodeverk.ProsjektResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonProsjektQueryResolver")
 public class ProsjektQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class ProsjektQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ProsjektService service;
 
-    public ProsjektResource getProsjekt(
+    public CompletionStage<ProsjektResource> getProsjekt(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getProsjektResourceById("systemid", systemId, dfe);
+            return service.getProsjektResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<ProsjektResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/prosjekt/ProsjektService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/prosjekt/ProsjektService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.ProsjektResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonProsjektService")
 public class ProsjektService {
@@ -17,7 +18,7 @@ public class ProsjektService {
     @Autowired
     private Endpoints endpoints;
 
-    public ProsjektResource getProsjektResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<ProsjektResource> getProsjektResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getProsjektResource(
             endpoints.getAdministrasjonKodeverk() 
                 + "/prosjekt/" 
@@ -27,7 +28,7 @@ public class ProsjektService {
             dfe);
     }
 
-    public ProsjektResource getProsjektResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<ProsjektResource> getProsjektResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, ProsjektResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/ramme/RammeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/ramme/RammeQueryResolver.java
@@ -1,0 +1,28 @@
+
+package no.fint.graphql.model.administrasjon.ramme;
+
+import com.coxautodev.graphql.tools.GraphQLQueryResolver;
+import graphql.schema.DataFetchingEnvironment;
+import no.fint.model.resource.administrasjon.kodeverk.RammeResource;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
+
+@Component("administrasjonRammeQueryResolver")
+public class RammeQueryResolver implements GraphQLQueryResolver {
+
+    @Autowired
+    private RammeService service;
+
+    public CompletionStage<RammeResource> getRamme(
+            String systemId,
+            DataFetchingEnvironment dfe) {
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getRammeResourceById("systemid", systemId, dfe).toFuture();
+        }
+        return Mono.<RammeResource>empty().toFuture();
+    }
+}

--- a/src/main/java/no/fint/graphql/model/administrasjon/ramme/RammeResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/ramme/RammeResolver.java
@@ -1,0 +1,40 @@
+
+package no.fint.graphql.model.administrasjon.ramme;
+
+import com.coxautodev.graphql.tools.GraphQLResolver;
+import graphql.schema.DataFetchingEnvironment;
+
+import no.fint.graphql.model.administrasjon.fullmakt.FullmaktService;
+
+
+import no.fint.model.resource.Link;
+import no.fint.model.resource.administrasjon.kodeverk.RammeResource;
+import no.fint.model.resource.administrasjon.fullmakt.FullmaktResource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+@Component("administrasjonRammeResolver")
+public class RammeResolver implements GraphQLResolver<RammeResource> {
+
+    @Autowired
+    private FullmaktService fullmaktService;
+
+
+    public CompletionStage<List<FullmaktResource>> getFullmakt(RammeResource ramme, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(ramme.getFullmakt()
+                .stream()
+                .map(Link::getHref)
+                .map(l -> fullmaktService.getFullmaktResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
+    }
+
+}
+

--- a/src/main/java/no/fint/graphql/model/administrasjon/ramme/RammeService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/ramme/RammeService.java
@@ -1,0 +1,35 @@
+
+package no.fint.graphql.model.administrasjon.ramme;
+
+import graphql.schema.DataFetchingEnvironment;
+import no.fint.graphql.WebClientRequest;
+import no.fint.graphql.model.Endpoints;
+import no.fint.model.resource.administrasjon.kodeverk.RammeResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service("administrasjonRammeService")
+public class RammeService {
+
+    @Autowired
+    private WebClientRequest webClientRequest;
+
+    @Autowired
+    private Endpoints endpoints;
+
+    public Mono<RammeResource> getRammeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return getRammeResource(
+            endpoints.getAdministrasjonKodeverk() 
+                + "/ramme/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
+    }
+
+    public Mono<RammeResource> getRammeResource(String url, DataFetchingEnvironment dfe) {
+        return webClientRequest.get(url, RammeResource.class, dfe);
+    }
+}
+

--- a/src/main/java/no/fint/graphql/model/administrasjon/rolle/RolleQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/rolle/RolleQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.fullmakt.RolleResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonRolleQueryResolver")
 public class RolleQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class RolleQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private RolleService service;
 
-    public RolleResource getRolle(
+    public CompletionStage<RolleResource> getRolle(
             String navn,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(navn)) {
-            return service.getRolleResourceById("navn", navn, dfe);
+            return service.getRolleResourceById("navn", navn, dfe).toFuture();
         }
-        return null;
+        return Mono.<RolleResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/rolle/RolleService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/rolle/RolleService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.fullmakt.RolleResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonRolleService")
 public class RolleService {
@@ -17,7 +18,7 @@ public class RolleService {
     @Autowired
     private Endpoints endpoints;
 
-    public RolleResource getRolleResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<RolleResource> getRolleResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getRolleResource(
             endpoints.getAdministrasjonFullmakt() 
                 + "/rolle/" 
@@ -27,7 +28,7 @@ public class RolleService {
             dfe);
     }
 
-    public RolleResource getRolleResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<RolleResource> getRolleResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, RolleResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.kodeverk.StillingskodeResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonStillingskodeQueryResolver")
 public class StillingskodeQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class StillingskodeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private StillingskodeService service;
 
-    public StillingskodeResource getStillingskode(
+    public CompletionStage<StillingskodeResource> getStillingskode(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getStillingskodeResourceById("systemid", systemId, dfe);
+            return service.getStillingskodeResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<StillingskodeResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeResolver.java
@@ -32,7 +32,7 @@ public class StillingskodeResolver implements GraphQLResolver<StillingskodeResou
                 .map(Link::getHref)
                 .map(l -> stillingskodeService.getStillingskodeResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeResolver.java
@@ -13,10 +13,11 @@ import no.fint.model.resource.administrasjon.kodeverk.StillingskodeResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonStillingskodeResolver")
 public class StillingskodeResolver implements GraphQLResolver<StillingskodeResource> {
@@ -25,13 +26,14 @@ public class StillingskodeResolver implements GraphQLResolver<StillingskodeResou
     private StillingskodeService stillingskodeService;
 
 
-    public StillingskodeResource getForelder(StillingskodeResource stillingskode, DataFetchingEnvironment dfe) {
-        return stillingskode.getForelder()
+    public CompletionStage<StillingskodeResource> getForelder(StillingskodeResource stillingskode, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(stillingskode.getForelder()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> stillingskodeService.getStillingskodeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> stillingskodeService.getStillingskodeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/stillingskode/StillingskodeService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.StillingskodeResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonStillingskodeService")
 public class StillingskodeService {
@@ -17,7 +18,7 @@ public class StillingskodeService {
     @Autowired
     private Endpoints endpoints;
 
-    public StillingskodeResource getStillingskodeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<StillingskodeResource> getStillingskodeResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getStillingskodeResource(
             endpoints.getAdministrasjonKodeverk() 
                 + "/stillingskode/" 
@@ -27,7 +28,7 @@ public class StillingskodeService {
             dfe);
     }
 
-    public StillingskodeResource getStillingskodeResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<StillingskodeResource> getStillingskodeResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, StillingskodeResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/uketimetall/UketimetallQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/uketimetall/UketimetallQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.kodeverk.UketimetallResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonUketimetallQueryResolver")
 public class UketimetallQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class UketimetallQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private UketimetallService service;
 
-    public UketimetallResource getUketimetall(
+    public CompletionStage<UketimetallResource> getUketimetall(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getUketimetallResourceById("systemid", systemId, dfe);
+            return service.getUketimetallResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<UketimetallResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/uketimetall/UketimetallService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/uketimetall/UketimetallService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.kodeverk.UketimetallResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonUketimetallService")
 public class UketimetallService {
@@ -17,7 +18,7 @@ public class UketimetallService {
     @Autowired
     private Endpoints endpoints;
 
-    public UketimetallResource getUketimetallResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<UketimetallResource> getUketimetallResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getUketimetallResource(
             endpoints.getAdministrasjonKodeverk() 
                 + "/uketimetall/" 
@@ -27,7 +28,7 @@ public class UketimetallService {
             dfe);
     }
 
-    public UketimetallResource getUketimetallResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<UketimetallResource> getUketimetallResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, UketimetallResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.administrasjon.personal.VariabellonnResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonVariabellonnQueryResolver")
 public class VariabellonnQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,16 @@ public class VariabellonnQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private VariabellonnService service;
 
-    public VariabellonnResource getVariabellonn(
+    public CompletionStage<VariabellonnResource> getVariabellonn(
+            String kildesystemId,
             String systemId,
             DataFetchingEnvironment dfe) {
-        if (StringUtils.isNotEmpty(systemId)) {
-            return service.getVariabellonnResourceById("systemid", systemId, dfe);
+        if (StringUtils.isNotEmpty(kildesystemId)) {
+            return service.getVariabellonnResourceById("kildesystemid", kildesystemId, dfe).toFuture();
         }
-        return null;
+        if (StringUtils.isNotEmpty(systemId)) {
+            return service.getVariabellonnResourceById("systemid", systemId, dfe).toFuture();
+        }
+        return Mono.<VariabellonnResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnResolver.java
@@ -17,10 +17,11 @@ import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("administrasjonVariabellonnResolver")
 public class VariabellonnResolver implements GraphQLResolver<VariabellonnResource> {
@@ -35,49 +36,54 @@ public class VariabellonnResolver implements GraphQLResolver<VariabellonnResourc
     private PersonalressursService personalressursService;
 
 
-    public LonnsartResource getLonnsart(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
-        return variabellonn.getLonnsart()
+    public CompletionStage<LonnsartResource> getLonnsart(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(variabellonn.getLonnsart()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> lonnsartService.getLonnsartResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> lonnsartService.getLonnsartResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public ArbeidsforholdResource getArbeidsforhold(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
-        return variabellonn.getArbeidsforhold()
+    public CompletionStage<ArbeidsforholdResource> getArbeidsforhold(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(variabellonn.getArbeidsforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public PersonalressursResource getAnviser(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
-        return variabellonn.getAnviser()
+    public CompletionStage<PersonalressursResource> getAnviser(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(variabellonn.getAnviser()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public PersonalressursResource getKonterer(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
-        return variabellonn.getKonterer()
+    public CompletionStage<PersonalressursResource> getKonterer(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(variabellonn.getKonterer()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public PersonalressursResource getAttestant(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
-        return variabellonn.getAttestant()
+    public CompletionStage<PersonalressursResource> getAttestant(VariabellonnResource variabellonn, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(variabellonn.getAttestant()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnResolver.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnResolver.java
@@ -42,7 +42,7 @@ public class VariabellonnResolver implements GraphQLResolver<VariabellonnResourc
                 .map(Link::getHref)
                 .map(l -> lonnsartService.getLonnsartResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -52,7 +52,7 @@ public class VariabellonnResolver implements GraphQLResolver<VariabellonnResourc
                 .map(Link::getHref)
                 .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -62,7 +62,7 @@ public class VariabellonnResolver implements GraphQLResolver<VariabellonnResourc
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -72,7 +72,7 @@ public class VariabellonnResolver implements GraphQLResolver<VariabellonnResourc
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -82,7 +82,7 @@ public class VariabellonnResolver implements GraphQLResolver<VariabellonnResourc
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnService.java
+++ b/src/main/java/no/fint/graphql/model/administrasjon/variabellonn/VariabellonnService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.administrasjon.personal.VariabellonnResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("administrasjonVariabellonnService")
 public class VariabellonnService {
@@ -17,7 +18,7 @@ public class VariabellonnService {
     @Autowired
     private Endpoints endpoints;
 
-    public VariabellonnResource getVariabellonnResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<VariabellonnResource> getVariabellonnResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getVariabellonnResource(
             endpoints.getAdministrasjonPersonal() 
                 + "/variabellonn/" 
@@ -27,7 +28,7 @@ public class VariabellonnService {
             dfe);
     }
 
-    public VariabellonnResource getVariabellonnResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<VariabellonnResource> getVariabellonnResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, VariabellonnResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/adresse/AdresseResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/adresse/AdresseResolver.java
@@ -13,10 +13,11 @@ import no.fint.model.resource.felles.kodeverk.iso.LandkodeResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("fellesAdresseResolver")
 public class AdresseResolver implements GraphQLResolver<AdresseResource> {
@@ -25,13 +26,14 @@ public class AdresseResolver implements GraphQLResolver<AdresseResource> {
     private LandkodeService landkodeService;
 
 
-    public LandkodeResource getLand(AdresseResource adresse, DataFetchingEnvironment dfe) {
-        return adresse.getLand()
+    public CompletionStage<LandkodeResource> getLand(AdresseResource adresse, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(adresse.getLand()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> landkodeService.getLandkodeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> landkodeService.getLandkodeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/felles/adresse/AdresseResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/adresse/AdresseResolver.java
@@ -32,7 +32,7 @@ public class AdresseResolver implements GraphQLResolver<AdresseResource> {
                 .map(Link::getHref)
                 .map(l -> landkodeService.getLandkodeResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/felles/fylke/FylkeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/fylke/FylkeQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.felles.kodeverk.FylkeResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("fellesFylkeQueryResolver")
 public class FylkeQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class FylkeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private FylkeService service;
 
-    public FylkeResource getFylke(
+    public CompletionStage<FylkeResource> getFylke(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getFylkeResourceById("systemid", systemId, dfe);
+            return service.getFylkeResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<FylkeResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/fylke/FylkeResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/fylke/FylkeResolver.java
@@ -13,10 +13,11 @@ import no.fint.model.resource.felles.kodeverk.KommuneResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("fellesFylkeResolver")
 public class FylkeResolver implements GraphQLResolver<FylkeResource> {
@@ -25,13 +26,14 @@ public class FylkeResolver implements GraphQLResolver<FylkeResource> {
     private KommuneService kommuneService;
 
 
-    public List<KommuneResource> getKommune(FylkeResource fylke, DataFetchingEnvironment dfe) {
-        return fylke.getKommune()
+    public CompletionStage<List<KommuneResource>> getKommune(FylkeResource fylke, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fylke.getKommune()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> kommuneService.getKommuneResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> kommuneService.getKommuneResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/felles/fylke/FylkeService.java
+++ b/src/main/java/no/fint/graphql/model/felles/fylke/FylkeService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.felles.kodeverk.FylkeResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("fellesFylkeService")
 public class FylkeService {
@@ -17,7 +18,7 @@ public class FylkeService {
     @Autowired
     private Endpoints endpoints;
 
-    public FylkeResource getFylkeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<FylkeResource> getFylkeResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getFylkeResource(
             endpoints.getFellesKodeverk() 
                 + "/fylke/" 
@@ -27,7 +28,7 @@ public class FylkeService {
             dfe);
     }
 
-    public FylkeResource getFylkeResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<FylkeResource> getFylkeResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, FylkeResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/kjonn/KjonnQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/kjonn/KjonnQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.felles.kodeverk.iso.KjonnResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("fellesKjonnQueryResolver")
 public class KjonnQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class KjonnQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private KjonnService service;
 
-    public KjonnResource getKjonn(
+    public CompletionStage<KjonnResource> getKjonn(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getKjonnResourceById("systemid", systemId, dfe).block();
+            return service.getKjonnResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<KjonnResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/kjonn/KjonnQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/kjonn/KjonnQueryResolver.java
@@ -18,7 +18,7 @@ public class KjonnQueryResolver implements GraphQLQueryResolver {
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getKjonnResourceById("systemid", systemId, dfe);
+            return service.getKjonnResourceById("systemid", systemId, dfe).block();
         }
         return null;
     }

--- a/src/main/java/no/fint/graphql/model/felles/kjonn/KjonnService.java
+++ b/src/main/java/no/fint/graphql/model/felles/kjonn/KjonnService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.felles.kodeverk.iso.KjonnResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("fellesKjonnService")
 public class KjonnService {
@@ -17,7 +18,7 @@ public class KjonnService {
     @Autowired
     private Endpoints endpoints;
 
-    public KjonnResource getKjonnResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<KjonnResource> getKjonnResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getKjonnResource(
             endpoints.getFellesKodeverkIso() 
                 + "/kjonn/" 
@@ -27,8 +28,8 @@ public class KjonnService {
             dfe);
     }
 
-    public KjonnResource getKjonnResource(String url, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(url, KjonnResource.class, dfe);
+    public Mono<KjonnResource> getKjonnResource(String url, DataFetchingEnvironment dfe) {
+        return webClientRequest.getMono(url, KjonnResource.class, dfe).cache();
     }
 }
 

--- a/src/main/java/no/fint/graphql/model/felles/kjonn/KjonnService.java
+++ b/src/main/java/no/fint/graphql/model/felles/kjonn/KjonnService.java
@@ -29,7 +29,7 @@ public class KjonnService {
     }
 
     public Mono<KjonnResource> getKjonnResource(String url, DataFetchingEnvironment dfe) {
-        return webClientRequest.getMono(url, KjonnResource.class, dfe).cache();
+        return webClientRequest.get(url, KjonnResource.class, dfe);
     }
 }
 

--- a/src/main/java/no/fint/graphql/model/felles/kommune/KommuneQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/kommune/KommuneQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.felles.kodeverk.KommuneResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("fellesKommuneQueryResolver")
 public class KommuneQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class KommuneQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private KommuneService service;
 
-    public KommuneResource getKommune(
+    public CompletionStage<KommuneResource> getKommune(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getKommuneResourceById("systemid", systemId, dfe);
+            return service.getKommuneResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<KommuneResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/kommune/KommuneResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/kommune/KommuneResolver.java
@@ -32,7 +32,7 @@ public class KommuneResolver implements GraphQLResolver<KommuneResource> {
                 .map(Link::getHref)
                 .map(l -> fylkeService.getFylkeResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/felles/kommune/KommuneService.java
+++ b/src/main/java/no/fint/graphql/model/felles/kommune/KommuneService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.felles.kodeverk.KommuneResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("fellesKommuneService")
 public class KommuneService {
@@ -17,7 +18,7 @@ public class KommuneService {
     @Autowired
     private Endpoints endpoints;
 
-    public KommuneResource getKommuneResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<KommuneResource> getKommuneResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getKommuneResource(
             endpoints.getFellesKodeverk() 
                 + "/kommune/" 
@@ -27,7 +28,7 @@ public class KommuneService {
             dfe);
     }
 
-    public KommuneResource getKommuneResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<KommuneResource> getKommuneResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, KommuneResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.felles.KontaktpersonResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("fellesKontaktpersonQueryResolver")
 public class KontaktpersonQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class KontaktpersonQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private KontaktpersonService service;
 
-    public KontaktpersonResource getKontaktperson(
+    public CompletionStage<KontaktpersonResource> getKontaktperson(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getKontaktpersonResourceById("systemid", systemId, dfe);
+            return service.getKontaktpersonResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<KontaktpersonResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonResolver.java
@@ -13,10 +13,12 @@ import no.fint.model.resource.felles.PersonResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("fellesKontaktpersonResolver")
 public class KontaktpersonResolver implements GraphQLResolver<KontaktpersonResource> {
@@ -25,22 +27,26 @@ public class KontaktpersonResolver implements GraphQLResolver<KontaktpersonResou
     private PersonService personService;
 
 
-    public List<PersonResource> getKontaktperson(KontaktpersonResource kontaktperson, DataFetchingEnvironment dfe) {
-        return kontaktperson.getKontaktperson()
+    public CompletionStage<List<PersonResource>> getKontaktperson(KontaktpersonResource kontaktperson, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontaktperson.getKontaktperson()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personService.getPersonResource(l, dfe))
+                .map(l -> personService.getPersonResource(l, dfe)))
+                .flatMap(Mono::flux)
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .collectList()
+                .toFuture();
     }
 
-    public PersonResource getPerson(KontaktpersonResource kontaktperson, DataFetchingEnvironment dfe) {
-        return kontaktperson.getPerson()
+    public CompletionStage<PersonResource> getPerson(KontaktpersonResource kontaktperson, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontaktperson.getPerson()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personService.getPersonResource(l, dfe))
+                .map(l -> personService.getPersonResource(l, dfe)))
+                .flatMap(Mono::flux)
                 .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .singleOrEmpty()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonResolver.java
@@ -42,7 +42,7 @@ public class KontaktpersonResolver implements GraphQLResolver<KontaktpersonResou
                 .map(Link::getHref)
                 .map(l -> personService.getPersonResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonResolver.java
@@ -17,7 +17,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 
 @Component("fellesKontaktpersonResolver")
@@ -33,7 +32,6 @@ public class KontaktpersonResolver implements GraphQLResolver<KontaktpersonResou
                 .map(Link::getHref)
                 .map(l -> personService.getPersonResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .filter(Objects::nonNull)
                 .collectList()
                 .toFuture();
     }
@@ -44,7 +42,6 @@ public class KontaktpersonResolver implements GraphQLResolver<KontaktpersonResou
                 .map(Link::getHref)
                 .map(l -> personService.getPersonResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .filter(Objects::nonNull)
                 .singleOrEmpty()
                 .toFuture();
     }

--- a/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonService.java
+++ b/src/main/java/no/fint/graphql/model/felles/kontaktperson/KontaktpersonService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.felles.KontaktpersonResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("fellesKontaktpersonService")
 public class KontaktpersonService {
@@ -17,7 +18,7 @@ public class KontaktpersonService {
     @Autowired
     private Endpoints endpoints;
 
-    public KontaktpersonResource getKontaktpersonResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<KontaktpersonResource> getKontaktpersonResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getKontaktpersonResource(
             endpoints.getFelles() 
                 + "/kontaktperson/" 
@@ -27,7 +28,7 @@ public class KontaktpersonService {
             dfe);
     }
 
-    public KontaktpersonResource getKontaktpersonResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<KontaktpersonResource> getKontaktpersonResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, KontaktpersonResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/landkode/LandkodeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/landkode/LandkodeQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.felles.kodeverk.iso.LandkodeResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("fellesLandkodeQueryResolver")
 public class LandkodeQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class LandkodeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private LandkodeService service;
 
-    public LandkodeResource getLandkode(
+    public CompletionStage<LandkodeResource> getLandkode(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getLandkodeResourceById("systemid", systemId, dfe);
+            return service.getLandkodeResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<LandkodeResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/landkode/LandkodeService.java
+++ b/src/main/java/no/fint/graphql/model/felles/landkode/LandkodeService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.felles.kodeverk.iso.LandkodeResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("fellesLandkodeService")
 public class LandkodeService {
@@ -17,7 +18,7 @@ public class LandkodeService {
     @Autowired
     private Endpoints endpoints;
 
-    public LandkodeResource getLandkodeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<LandkodeResource> getLandkodeResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getLandkodeResource(
             endpoints.getFellesKodeverkIso() 
                 + "/landkode/" 
@@ -27,7 +28,7 @@ public class LandkodeService {
             dfe);
     }
 
-    public LandkodeResource getLandkodeResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<LandkodeResource> getLandkodeResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, LandkodeResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/person/PersonQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/person/PersonQueryResolver.java
@@ -18,7 +18,7 @@ public class PersonQueryResolver implements GraphQLQueryResolver {
             String fodselsnummer,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(fodselsnummer)) {
-            return service.getPersonResourceById("fodselsnummer", fodselsnummer, dfe);
+            return service.getPersonResourceById("fodselsnummer", fodselsnummer, dfe).block();
         }
         return null;
     }

--- a/src/main/java/no/fint/graphql/model/felles/person/PersonQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/person/PersonQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.felles.PersonResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("fellesPersonQueryResolver")
 public class PersonQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class PersonQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private PersonService service;
 
-    public PersonResource getPerson(
+    public CompletionStage<PersonResource> getPerson(
             String fodselsnummer,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(fodselsnummer)) {
-            return service.getPersonResourceById("fodselsnummer", fodselsnummer, dfe).block();
+            return service.getPersonResourceById("fodselsnummer", fodselsnummer, dfe).toFuture();
         }
-        return null;
+        return Mono.<PersonResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/person/PersonResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/person/PersonResolver.java
@@ -6,6 +6,7 @@ import graphql.schema.DataFetchingEnvironment;
 
 import no.fint.graphql.model.felles.landkode.LandkodeService;
 import no.fint.graphql.model.felles.kjonn.KjonnService;
+import no.fint.graphql.model.felles.person.PersonService;
 import no.fint.graphql.model.felles.sprak.SprakService;
 import no.fint.graphql.model.administrasjon.personalressurs.PersonalressursService;
 import no.fint.graphql.model.felles.kontaktperson.KontaktpersonService;
@@ -16,6 +17,7 @@ import no.fint.model.resource.Link;
 import no.fint.model.resource.felles.PersonResource;
 import no.fint.model.resource.felles.kodeverk.iso.LandkodeResource;
 import no.fint.model.resource.felles.kodeverk.iso.KjonnResource;
+import no.fint.model.resource.felles.PersonResource;
 import no.fint.model.resource.felles.kodeverk.iso.SprakResource;
 import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
 import no.fint.model.resource.felles.KontaktpersonResource;
@@ -27,9 +29,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 @Component("fellesPersonResolver")
 public class PersonResolver implements GraphQLResolver<PersonResource> {
@@ -56,13 +56,14 @@ public class PersonResolver implements GraphQLResolver<PersonResource> {
     private ElevService elevService;
 
 
-    public List<LandkodeResource> getStatsborgerskap(PersonResource person, DataFetchingEnvironment dfe) {
-        return person.getStatsborgerskap()
+    public CompletionStage<List<LandkodeResource>> getStatsborgerskap(PersonResource person, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(person.getStatsborgerskap()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> landkodeService.getLandkodeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> landkodeService.getLandkodeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
     public CompletionStage<KjonnResource> getKjonn(PersonResource person, DataFetchingEnvironment dfe) {
@@ -71,7 +72,6 @@ public class PersonResolver implements GraphQLResolver<PersonResource> {
                 .map(Link::getHref)
                 .map(l -> kjonnService.getKjonnResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .filter(Objects::nonNull)
                 .singleOrEmpty()
                 .toFuture();
     }
@@ -82,45 +82,48 @@ public class PersonResolver implements GraphQLResolver<PersonResource> {
                 .map(Link::getHref)
                 .map(l -> personService.getPersonResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .filter(Objects::nonNull)
                 .collectList()
                 .toFuture();
     }
 
-    public SprakResource getMalform(PersonResource person, DataFetchingEnvironment dfe) {
-        return person.getMalform()
+    public CompletionStage<SprakResource> getMalform(PersonResource person, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(person.getMalform()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> sprakService.getSprakResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> sprakService.getSprakResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public PersonalressursResource getPersonalressurs(PersonResource person, DataFetchingEnvironment dfe) {
-        return person.getPersonalressurs()
+    public CompletionStage<PersonalressursResource> getPersonalressurs(PersonResource person, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(person.getPersonalressurs()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personalressursService.getPersonalressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public SprakResource getMorsmal(PersonResource person, DataFetchingEnvironment dfe) {
-        return person.getMorsmal()
+    public CompletionStage<SprakResource> getMorsmal(PersonResource person, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(person.getMorsmal()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> sprakService.getSprakResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> sprakService.getSprakResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public List<KontaktpersonResource> getParorende(PersonResource person, DataFetchingEnvironment dfe) {
-        return person.getParorende()
+    public CompletionStage<List<KontaktpersonResource>> getParorende(PersonResource person, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(person.getParorende()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> kontaktpersonService.getKontaktpersonResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> kontaktpersonService.getKontaktpersonResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
     public CompletionStage<List<PersonResource>> getForeldre(PersonResource person, DataFetchingEnvironment dfe) {
@@ -129,7 +132,6 @@ public class PersonResolver implements GraphQLResolver<PersonResource> {
                 .map(Link::getHref)
                 .map(l -> personService.getPersonResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .filter(Objects::nonNull)
                 .collectList()
                 .toFuture();
     }
@@ -140,7 +142,6 @@ public class PersonResolver implements GraphQLResolver<PersonResource> {
                 .map(Link::getHref)
                 .map(l -> elevService.getElevResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .filter(Objects::nonNull)
                 .singleOrEmpty()
                 .toFuture();
     }

--- a/src/main/java/no/fint/graphql/model/felles/person/PersonResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/person/PersonResolver.java
@@ -72,7 +72,7 @@ public class PersonResolver implements GraphQLResolver<PersonResource> {
                 .map(Link::getHref)
                 .map(l -> kjonnService.getKjonnResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -92,7 +92,7 @@ public class PersonResolver implements GraphQLResolver<PersonResource> {
                 .map(Link::getHref)
                 .map(l -> sprakService.getSprakResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -102,7 +102,7 @@ public class PersonResolver implements GraphQLResolver<PersonResource> {
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -112,7 +112,7 @@ public class PersonResolver implements GraphQLResolver<PersonResource> {
                 .map(Link::getHref)
                 .map(l -> sprakService.getSprakResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -142,7 +142,7 @@ public class PersonResolver implements GraphQLResolver<PersonResource> {
                 .map(Link::getHref)
                 .map(l -> elevService.getElevResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/felles/person/PersonResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/person/PersonResolver.java
@@ -6,7 +6,6 @@ import graphql.schema.DataFetchingEnvironment;
 
 import no.fint.graphql.model.felles.landkode.LandkodeService;
 import no.fint.graphql.model.felles.kjonn.KjonnService;
-import no.fint.graphql.model.felles.person.PersonService;
 import no.fint.graphql.model.felles.sprak.SprakService;
 import no.fint.graphql.model.administrasjon.personalressurs.PersonalressursService;
 import no.fint.graphql.model.felles.kontaktperson.KontaktpersonService;
@@ -17,7 +16,6 @@ import no.fint.model.resource.Link;
 import no.fint.model.resource.felles.PersonResource;
 import no.fint.model.resource.felles.kodeverk.iso.LandkodeResource;
 import no.fint.model.resource.felles.kodeverk.iso.KjonnResource;
-import no.fint.model.resource.felles.PersonResource;
 import no.fint.model.resource.felles.kodeverk.iso.SprakResource;
 import no.fint.model.resource.administrasjon.personal.PersonalressursResource;
 import no.fint.model.resource.felles.KontaktpersonResource;
@@ -25,9 +23,12 @@ import no.fint.model.resource.utdanning.elev.ElevResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 @Component("fellesPersonResolver")
@@ -64,22 +65,26 @@ public class PersonResolver implements GraphQLResolver<PersonResource> {
                 .collect(Collectors.toList());
     }
 
-    public KjonnResource getKjonn(PersonResource person, DataFetchingEnvironment dfe) {
-        return person.getKjonn()
+    public CompletionStage<KjonnResource> getKjonn(PersonResource person, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(person.getKjonn()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> kjonnService.getKjonnResource(l, dfe))
+                .map(l -> kjonnService.getKjonnResource(l, dfe)))
+                .flatMap(Mono::flux)
                 .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public List<PersonResource> getForeldreansvar(PersonResource person, DataFetchingEnvironment dfe) {
-        return person.getForeldreansvar()
+    public CompletionStage<List<PersonResource>> getForeldreansvar(PersonResource person, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(person.getForeldreansvar()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personService.getPersonResource(l, dfe))
+                .map(l -> personService.getPersonResource(l, dfe)))
+                .flatMap(Mono::flux)
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .collectList()
+                .toFuture();
     }
 
     public SprakResource getMalform(PersonResource person, DataFetchingEnvironment dfe) {
@@ -118,22 +123,26 @@ public class PersonResolver implements GraphQLResolver<PersonResource> {
                 .collect(Collectors.toList());
     }
 
-    public List<PersonResource> getForeldre(PersonResource person, DataFetchingEnvironment dfe) {
-        return person.getForeldre()
+    public CompletionStage<List<PersonResource>> getForeldre(PersonResource person, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(person.getForeldre()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personService.getPersonResource(l, dfe))
+                .map(l -> personService.getPersonResource(l, dfe)))
+                .flatMap(Mono::flux)
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .collectList()
+                .toFuture();
     }
 
-    public ElevResource getElev(PersonResource person, DataFetchingEnvironment dfe) {
-        return person.getElev()
+    public CompletionStage<ElevResource> getElev(PersonResource person, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(person.getElev()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> elevService.getElevResource(l, dfe))
+                .map(l -> elevService.getElevResource(l, dfe)))
+                .flatMap(Mono::flux)
                 .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .singleOrEmpty()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/felles/person/PersonService.java
+++ b/src/main/java/no/fint/graphql/model/felles/person/PersonService.java
@@ -32,7 +32,7 @@ public class PersonService {
                 .map(r -> getPersonResource(r, dfe)))
                 .flatMap(Mono::flux)
                 .filter(Objects::nonNull)
-                .singleOrEmpty();
+                .next();
     }
 
     public Mono<PersonResource> getPersonResource(String url, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/felles/person/PersonService.java
+++ b/src/main/java/no/fint/graphql/model/felles/person/PersonService.java
@@ -7,11 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.felles.PersonResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import java.util.Objects;
-import java.util.stream.Stream;
 
 @Service("fellesPersonService")
 public class PersonService {
@@ -23,20 +19,17 @@ public class PersonService {
     private Endpoints endpoints;
 
     public Mono<PersonResource> getPersonResourceById(String id, String value, DataFetchingEnvironment dfe) {
-        return Flux.fromStream(Stream
-                .of(endpoints.getAdministrasjonPersonal(), endpoints.getUtdanningElev(), endpoints.getFelles())
-                .map(e -> e + "/person/"
-                        + id
-                        + "/"
-                        + value)
-                .map(r -> getPersonResource(r, dfe)))
-                .flatMap(Mono::flux)
-                .filter(Objects::nonNull)
-                .singleOrEmpty();
+        return getPersonResource(
+            endpoints.getFelles() 
+                + "/person/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public Mono<PersonResource> getPersonResource(String url, DataFetchingEnvironment dfe) {
-        return webClientRequest.getMono(url, PersonResource.class, dfe);
+        return webClientRequest.get(url, PersonResource.class, dfe);
     }
 }
 

--- a/src/main/java/no/fint/graphql/model/felles/person/PersonService.java
+++ b/src/main/java/no/fint/graphql/model/felles/person/PersonService.java
@@ -7,6 +7,8 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.felles.PersonResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -20,21 +22,21 @@ public class PersonService {
     @Autowired
     private Endpoints endpoints;
 
-    public PersonResource getPersonResourceById(String id, String value, DataFetchingEnvironment dfe) {
-        return Stream
+    public Mono<PersonResource> getPersonResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(Stream
                 .of(endpoints.getAdministrasjonPersonal(), endpoints.getUtdanningElev(), endpoints.getFelles())
                 .map(e -> e + "/person/"
                         + id
                         + "/"
                         + value)
-                .map(r -> getPersonResource(r, dfe))
+                .map(r -> getPersonResource(r, dfe)))
+                .flatMap(Mono::flux)
                 .filter(Objects::nonNull)
-                .findAny()
-                .orElse(null);
+                .singleOrEmpty();
     }
 
-    public PersonResource getPersonResource(String url, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(url, PersonResource.class, dfe);
+    public Mono<PersonResource> getPersonResource(String url, DataFetchingEnvironment dfe) {
+        return webClientRequest.getMono(url, PersonResource.class, dfe);
     }
 }
 

--- a/src/main/java/no/fint/graphql/model/felles/sprak/SprakQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/felles/sprak/SprakQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.felles.kodeverk.iso.SprakResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("fellesSprakQueryResolver")
 public class SprakQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class SprakQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private SprakService service;
 
-    public SprakResource getSprak(
+    public CompletionStage<SprakResource> getSprak(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getSprakResourceById("systemid", systemId, dfe);
+            return service.getSprakResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<SprakResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/felles/sprak/SprakService.java
+++ b/src/main/java/no/fint/graphql/model/felles/sprak/SprakService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.felles.kodeverk.iso.SprakResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("fellesSprakService")
 public class SprakService {
@@ -17,7 +18,7 @@ public class SprakService {
     @Autowired
     private Endpoints endpoints;
 
-    public SprakResource getSprakResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<SprakResource> getSprakResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getSprakResource(
             endpoints.getFellesKodeverkIso() 
                 + "/sprak/" 
@@ -27,7 +28,7 @@ public class SprakService {
             dfe);
     }
 
-    public SprakResource getSprakResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<SprakResource> getSprakResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, SprakResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/arstrinn/ArstrinnQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/arstrinn/ArstrinnQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.utdanningsprogram.ArstrinnResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningArstrinnQueryResolver")
 public class ArstrinnQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class ArstrinnQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ArstrinnService service;
 
-    public ArstrinnResource getArstrinn(
+    public CompletionStage<ArstrinnResource> getArstrinn(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getArstrinnResourceById("systemid", systemId, dfe);
+            return service.getArstrinnResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<ArstrinnResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/arstrinn/ArstrinnResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/arstrinn/ArstrinnResolver.java
@@ -17,10 +17,11 @@ import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningArstrinnResolver")
 public class ArstrinnResolver implements GraphQLResolver<ArstrinnResource> {
@@ -35,31 +36,34 @@ public class ArstrinnResolver implements GraphQLResolver<ArstrinnResource> {
     private MedlemskapService medlemskapService;
 
 
-    public List<ProgramomradeResource> getProgramomrade(ArstrinnResource arstrinn, DataFetchingEnvironment dfe) {
-        return arstrinn.getProgramomrade()
+    public CompletionStage<List<ProgramomradeResource>> getProgramomrade(ArstrinnResource arstrinn, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arstrinn.getProgramomrade()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> programomradeService.getProgramomradeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> programomradeService.getProgramomradeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<BasisgruppeResource> getBasisgruppe(ArstrinnResource arstrinn, DataFetchingEnvironment dfe) {
-        return arstrinn.getBasisgruppe()
+    public CompletionStage<List<BasisgruppeResource>> getBasisgruppe(ArstrinnResource arstrinn, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arstrinn.getBasisgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<MedlemskapResource> getMedlemskap(ArstrinnResource arstrinn, DataFetchingEnvironment dfe) {
-        return arstrinn.getMedlemskap()
+    public CompletionStage<List<MedlemskapResource>> getMedlemskap(ArstrinnResource arstrinn, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(arstrinn.getMedlemskap()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/arstrinn/ArstrinnService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/arstrinn/ArstrinnService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.utdanningsprogram.ArstrinnResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningArstrinnService")
 public class ArstrinnService {
@@ -17,7 +18,7 @@ public class ArstrinnService {
     @Autowired
     private Endpoints endpoints;
 
-    public ArstrinnResource getArstrinnResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<ArstrinnResource> getArstrinnResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getArstrinnResource(
             endpoints.getUtdanningUtdanningsprogram() 
                 + "/arstrinn/" 
@@ -27,7 +28,7 @@ public class ArstrinnService {
             dfe);
     }
 
-    public ArstrinnResource getArstrinnResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<ArstrinnResource> getArstrinnResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, ArstrinnResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.elev.BasisgruppeResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningBasisgruppeQueryResolver")
 public class BasisgruppeQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class BasisgruppeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private BasisgruppeService service;
 
-    public BasisgruppeResource getBasisgruppe(
+    public CompletionStage<BasisgruppeResource> getBasisgruppe(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getBasisgruppeResourceById("systemid", systemId, dfe);
+            return service.getBasisgruppeResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<BasisgruppeResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeResolver.java
@@ -57,7 +57,7 @@ public class BasisgruppeResolver implements GraphQLResolver<BasisgruppeResource>
                 .map(Link::getHref)
                 .map(l -> arstrinnService.getArstrinnResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -67,7 +67,7 @@ public class BasisgruppeResolver implements GraphQLResolver<BasisgruppeResource>
                 .map(Link::getHref)
                 .map(l -> skoleService.getSkoleResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeResolver.java
@@ -27,9 +27,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 @Component("utdanningBasisgruppeResolver")
 public class BasisgruppeResolver implements GraphQLResolver<BasisgruppeResource> {
@@ -53,13 +51,14 @@ public class BasisgruppeResolver implements GraphQLResolver<BasisgruppeResource>
     private MedlemskapService medlemskapService;
 
 
-    public ArstrinnResource getTrinn(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
-        return basisgruppe.getTrinn()
+    public CompletionStage<ArstrinnResource> getTrinn(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(basisgruppe.getTrinn()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> arstrinnService.getArstrinnResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> arstrinnService.getArstrinnResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
     public CompletionStage<SkoleResource> getSkole(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
@@ -72,41 +71,44 @@ public class BasisgruppeResolver implements GraphQLResolver<BasisgruppeResource>
                 .toFuture();
     }
 
-    public List<UndervisningsforholdResource> getUndervisningsforhold(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
-        return basisgruppe.getUndervisningsforhold()
+    public CompletionStage<List<UndervisningsforholdResource>> getUndervisningsforhold(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(basisgruppe.getUndervisningsforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<ElevforholdResource> getElevforhold(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
+    public CompletionStage<List<ElevforholdResource>> getElevforhold(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
         return Flux.fromStream(basisgruppe.getElevforhold()
                 .stream()
                 .map(Link::getHref)
                 .map(l -> elevforholdService.getElevforholdResource(l, dfe)))
                 .flatMap(Mono::flux)
                 .collectList()
-                .block();
+                .toFuture();
     }
 
-    public List<KontaktlarergruppeResource> getKontaktlarergruppe(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
-        return basisgruppe.getKontaktlarergruppe()
+    public CompletionStage<List<KontaktlarergruppeResource>> getKontaktlarergruppe(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(basisgruppe.getKontaktlarergruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<MedlemskapResource> getMedlemskap(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
-        return basisgruppe.getMedlemskap()
+    public CompletionStage<List<MedlemskapResource>> getMedlemskap(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(basisgruppe.getMedlemskap()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeResolver.java
@@ -23,6 +23,8 @@ import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Objects;
@@ -78,12 +80,13 @@ public class BasisgruppeResolver implements GraphQLResolver<BasisgruppeResource>
     }
 
     public List<ElevforholdResource> getElevforhold(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {
-        return basisgruppe.getElevforhold()
+        return Flux.fromStream(basisgruppe.getElevforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> elevforholdService.getElevforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> elevforholdService.getElevforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .block();
     }
 
     public List<KontaktlarergruppeResource> getKontaktlarergruppe(BasisgruppeResource basisgruppe, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/basisgruppe/BasisgruppeService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.elev.BasisgruppeResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningBasisgruppeService")
 public class BasisgruppeService {
@@ -17,7 +18,7 @@ public class BasisgruppeService {
     @Autowired
     private Endpoints endpoints;
 
-    public BasisgruppeResource getBasisgruppeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<BasisgruppeResource> getBasisgruppeResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getBasisgruppeResource(
             endpoints.getUtdanningElev() 
                 + "/basisgruppe/" 
@@ -27,7 +28,7 @@ public class BasisgruppeService {
             dfe);
     }
 
-    public BasisgruppeResource getBasisgruppeResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<BasisgruppeResource> getBasisgruppeResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, BasisgruppeResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.vurdering.EksamensgruppeResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningEksamensgruppeQueryResolver")
 public class EksamensgruppeQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class EksamensgruppeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private EksamensgruppeService service;
 
-    public EksamensgruppeResource getEksamensgruppe(
+    public CompletionStage<EksamensgruppeResource> getEksamensgruppe(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getEksamensgruppeResourceById("systemid", systemId, dfe);
+            return service.getEksamensgruppeResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<EksamensgruppeResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeResolver.java
@@ -52,7 +52,7 @@ public class EksamensgruppeResolver implements GraphQLResolver<EksamensgruppeRes
                 .map(Link::getHref)
                 .map(l -> fagService.getFagResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -62,7 +62,7 @@ public class EksamensgruppeResolver implements GraphQLResolver<EksamensgruppeRes
                 .map(Link::getHref)
                 .map(l -> skoleService.getSkoleResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeResolver.java
@@ -25,9 +25,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 @Component("utdanningEksamensgruppeResolver")
 public class EksamensgruppeResolver implements GraphQLResolver<EksamensgruppeResource> {
@@ -48,13 +46,14 @@ public class EksamensgruppeResolver implements GraphQLResolver<EksamensgruppeRes
     private MedlemskapService medlemskapService;
 
 
-    public FagResource getFag(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
-        return eksamensgruppe.getFag()
+    public CompletionStage<FagResource> getFag(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(eksamensgruppe.getFag()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> fagService.getFagResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> fagService.getFagResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
     public CompletionStage<SkoleResource> getSkole(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
@@ -67,32 +66,34 @@ public class EksamensgruppeResolver implements GraphQLResolver<EksamensgruppeRes
                 .toFuture();
     }
 
-    public List<ElevforholdResource> getElevforhold(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
+    public CompletionStage<List<ElevforholdResource>> getElevforhold(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
         return Flux.fromStream(eksamensgruppe.getElevforhold()
                 .stream()
                 .map(Link::getHref)
                 .map(l -> elevforholdService.getElevforholdResource(l, dfe)))
                 .flatMap(Mono::flux)
                 .collectList()
-                .block();
+                .toFuture();
     }
 
-    public List<UndervisningsforholdResource> getUndervisningsforhold(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
-        return eksamensgruppe.getUndervisningsforhold()
+    public CompletionStage<List<UndervisningsforholdResource>> getUndervisningsforhold(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(eksamensgruppe.getUndervisningsforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<MedlemskapResource> getMedlemskap(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
-        return eksamensgruppe.getMedlemskap()
+    public CompletionStage<List<MedlemskapResource>> getMedlemskap(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(eksamensgruppe.getMedlemskap()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeResolver.java
@@ -21,6 +21,8 @@ import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Objects;
@@ -64,12 +66,13 @@ public class EksamensgruppeResolver implements GraphQLResolver<EksamensgruppeRes
     }
 
     public List<ElevforholdResource> getElevforhold(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {
-        return eksamensgruppe.getElevforhold()
+        return Flux.fromStream(eksamensgruppe.getElevforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> elevforholdService.getElevforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> elevforholdService.getElevforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .block();
     }
 
     public List<UndervisningsforholdResource> getUndervisningsforhold(EksamensgruppeResource eksamensgruppe, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/eksamensgruppe/EksamensgruppeService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.vurdering.EksamensgruppeResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningEksamensgruppeService")
 public class EksamensgruppeService {
@@ -17,7 +18,7 @@ public class EksamensgruppeService {
     @Autowired
     private Endpoints endpoints;
 
-    public EksamensgruppeResource getEksamensgruppeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<EksamensgruppeResource> getEksamensgruppeResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getEksamensgruppeResource(
             endpoints.getUtdanningVurdering() 
                 + "/eksamensgruppe/" 
@@ -27,7 +28,7 @@ public class EksamensgruppeService {
             dfe);
     }
 
-    public EksamensgruppeResource getEksamensgruppeResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<EksamensgruppeResource> getEksamensgruppeResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, EksamensgruppeResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/elev/ElevQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elev/ElevQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.elev.ElevResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningElevQueryResolver")
 public class ElevQueryResolver implements GraphQLQueryResolver {
@@ -14,24 +17,24 @@ public class ElevQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ElevService service;
 
-    public ElevResource getElev(
+    public CompletionStage<ElevResource> getElev(
             String brukernavn,
             String elevnummer,
             String feidenavn,
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(brukernavn)) {
-            return service.getElevResourceById("brukernavn", brukernavn, dfe).block();
+            return service.getElevResourceById("brukernavn", brukernavn, dfe).toFuture();
         }
         if (StringUtils.isNotEmpty(elevnummer)) {
-            return service.getElevResourceById("elevnummer", elevnummer, dfe).block();
+            return service.getElevResourceById("elevnummer", elevnummer, dfe).toFuture();
         }
         if (StringUtils.isNotEmpty(feidenavn)) {
-            return service.getElevResourceById("feidenavn", feidenavn, dfe).block();
+            return service.getElevResourceById("feidenavn", feidenavn, dfe).toFuture();
         }
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getElevResourceById("systemid", systemId, dfe).block();
+            return service.getElevResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<ElevResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/elev/ElevQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elev/ElevQueryResolver.java
@@ -21,16 +21,16 @@ public class ElevQueryResolver implements GraphQLQueryResolver {
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(brukernavn)) {
-            return service.getElevResourceById("brukernavn", brukernavn, dfe);
+            return service.getElevResourceById("brukernavn", brukernavn, dfe).block();
         }
         if (StringUtils.isNotEmpty(elevnummer)) {
-            return service.getElevResourceById("elevnummer", elevnummer, dfe);
+            return service.getElevResourceById("elevnummer", elevnummer, dfe).block();
         }
         if (StringUtils.isNotEmpty(feidenavn)) {
-            return service.getElevResourceById("feidenavn", feidenavn, dfe);
+            return service.getElevResourceById("feidenavn", feidenavn, dfe).block();
         }
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getElevResourceById("systemid", systemId, dfe);
+            return service.getElevResourceById("systemid", systemId, dfe).block();
         }
         return null;
     }

--- a/src/main/java/no/fint/graphql/model/utdanning/elev/ElevResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elev/ElevResolver.java
@@ -19,7 +19,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 
 @Component("utdanningElevResolver")
@@ -38,7 +37,6 @@ public class ElevResolver implements GraphQLResolver<ElevResource> {
                 .map(Link::getHref)
                 .map(l -> personService.getPersonResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .filter(Objects::nonNull)
                 .singleOrEmpty()
                 .toFuture();
     }

--- a/src/main/java/no/fint/graphql/model/utdanning/elev/ElevResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elev/ElevResolver.java
@@ -15,10 +15,12 @@ import no.fint.model.resource.utdanning.elev.ElevforholdResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningElevResolver")
 public class ElevResolver implements GraphQLResolver<ElevResource> {
@@ -30,22 +32,25 @@ public class ElevResolver implements GraphQLResolver<ElevResource> {
     private ElevforholdService elevforholdService;
 
 
-    public PersonResource getPerson(ElevResource elev, DataFetchingEnvironment dfe) {
-        return elev.getPerson()
+    public CompletionStage<PersonResource> getPerson(ElevResource elev, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(elev.getPerson()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> personService.getPersonResource(l, dfe))
+                .map(l -> personService.getPersonResource(l, dfe)))
+                .flatMap(Mono::flux)
                 .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public List<ElevforholdResource> getElevforhold(ElevResource elev, DataFetchingEnvironment dfe) {
-        return elev.getElevforhold()
+    public CompletionStage<List<ElevforholdResource>> getElevforhold(ElevResource elev, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(elev.getElevforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> elevforholdService.getElevforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> elevforholdService.getElevforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/elev/ElevResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elev/ElevResolver.java
@@ -37,7 +37,7 @@ public class ElevResolver implements GraphQLResolver<ElevResource> {
                 .map(Link::getHref)
                 .map(l -> personService.getPersonResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/elev/ElevService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elev/ElevService.java
@@ -29,7 +29,7 @@ public class ElevService {
     }
 
     public Mono<ElevResource> getElevResource(String url, DataFetchingEnvironment dfe) {
-        return webClientRequest.getMono(url, ElevResource.class, dfe);
+        return webClientRequest.get(url, ElevResource.class, dfe);
     }
 }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/elev/ElevService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elev/ElevService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.elev.ElevResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningElevService")
 public class ElevService {
@@ -17,7 +18,7 @@ public class ElevService {
     @Autowired
     private Endpoints endpoints;
 
-    public ElevResource getElevResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<ElevResource> getElevResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getElevResource(
             endpoints.getUtdanningElev() 
                 + "/elev/" 
@@ -27,8 +28,8 @@ public class ElevService {
             dfe);
     }
 
-    public ElevResource getElevResource(String url, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(url, ElevResource.class, dfe);
+    public Mono<ElevResource> getElevResource(String url, DataFetchingEnvironment dfe) {
+        return webClientRequest.getMono(url, ElevResource.class, dfe);
     }
 }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdQueryResolver.java
@@ -18,7 +18,7 @@ public class ElevforholdQueryResolver implements GraphQLQueryResolver {
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getElevforholdResourceById("systemid", systemId, dfe);
+            return service.getElevforholdResourceById("systemid", systemId, dfe).block();
         }
         return null;
     }

--- a/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.elev.ElevforholdResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningElevforholdQueryResolver")
 public class ElevforholdQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class ElevforholdQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ElevforholdService service;
 
-    public ElevforholdResource getElevforhold(
+    public CompletionStage<ElevforholdResource> getElevforhold(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getElevforholdResourceById("systemid", systemId, dfe).block();
+            return service.getElevforholdResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<ElevforholdResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdResolver.java
@@ -3,33 +3,39 @@ package no.fint.graphql.model.utdanning.elevforhold;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
+
 import no.fint.graphql.model.utdanning.basisgruppe.BasisgruppeService;
-import no.fint.graphql.model.utdanning.eksamensgruppe.EksamensgruppeService;
 import no.fint.graphql.model.utdanning.elev.ElevService;
 import no.fint.graphql.model.utdanning.elevkategori.ElevkategoriService;
-import no.fint.graphql.model.utdanning.kontaktlarergruppe.KontaktlarergruppeService;
-import no.fint.graphql.model.utdanning.medlemskap.MedlemskapService;
-import no.fint.graphql.model.utdanning.programomrade.ProgramomradeService;
 import no.fint.graphql.model.utdanning.skole.SkoleService;
+import no.fint.graphql.model.utdanning.eksamensgruppe.EksamensgruppeService;
+import no.fint.graphql.model.utdanning.kontaktlarergruppe.KontaktlarergruppeService;
+import no.fint.graphql.model.utdanning.programomrade.ProgramomradeService;
 import no.fint.graphql.model.utdanning.undervisningsgruppe.UndervisningsgruppeService;
 import no.fint.graphql.model.utdanning.vurdering.VurderingService;
+import no.fint.graphql.model.utdanning.medlemskap.MedlemskapService;
+
+
 import no.fint.model.resource.Link;
-import no.fint.model.resource.utdanning.elev.*;
+import no.fint.model.resource.utdanning.elev.ElevforholdResource;
+import no.fint.model.resource.utdanning.elev.BasisgruppeResource;
+import no.fint.model.resource.utdanning.elev.ElevResource;
 import no.fint.model.resource.utdanning.kodeverk.ElevkategoriResource;
-import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResource;
-import no.fint.model.resource.utdanning.utdanningsprogram.ProgramomradeResource;
 import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
 import no.fint.model.resource.utdanning.vurdering.EksamensgruppeResource;
+import no.fint.model.resource.utdanning.elev.KontaktlarergruppeResource;
+import no.fint.model.resource.utdanning.utdanningsprogram.ProgramomradeResource;
+import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResource;
 import no.fint.model.resource.utdanning.vurdering.VurderingResource;
+import no.fint.model.resource.utdanning.elev.MedlemskapResource;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 @Component("utdanningElevforholdResolver")
 public class ElevforholdResolver implements GraphQLResolver<ElevforholdResource> {
@@ -65,13 +71,14 @@ public class ElevforholdResolver implements GraphQLResolver<ElevforholdResource>
     private MedlemskapService medlemskapService;
 
 
-    public List<BasisgruppeResource> getBasisgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return elevforhold.getBasisgruppe()
+    public CompletionStage<List<BasisgruppeResource>> getBasisgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(elevforhold.getBasisgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
     public CompletionStage<ElevResource> getElev(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
@@ -80,18 +87,18 @@ public class ElevforholdResolver implements GraphQLResolver<ElevforholdResource>
                 .map(Link::getHref)
                 .map(l -> elevService.getElevResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .filter(Objects::nonNull)
                 .singleOrEmpty()
                 .toFuture();
     }
 
-    public ElevkategoriResource getKategori(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return elevforhold.getKategori()
+    public CompletionStage<ElevkategoriResource> getKategori(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(elevforhold.getKategori()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> elevkategoriService.getElevkategoriResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> elevkategoriService.getElevkategoriResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
     public CompletionStage<SkoleResource> getSkole(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
@@ -104,58 +111,64 @@ public class ElevforholdResolver implements GraphQLResolver<ElevforholdResource>
                 .toFuture();
     }
 
-    public List<EksamensgruppeResource> getEksamensgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return elevforhold.getEksamensgruppe()
+    public CompletionStage<List<EksamensgruppeResource>> getEksamensgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(elevforhold.getEksamensgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<KontaktlarergruppeResource> getKontaktlarergruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return elevforhold.getKontaktlarergruppe()
+    public CompletionStage<List<KontaktlarergruppeResource>> getKontaktlarergruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(elevforhold.getKontaktlarergruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public ProgramomradeResource getProgramomrade(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return elevforhold.getProgramomrade()
+    public CompletionStage<ProgramomradeResource> getProgramomrade(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(elevforhold.getProgramomrade()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> programomradeService.getProgramomradeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> programomradeService.getProgramomradeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public List<UndervisningsgruppeResource> getUndervisningsgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return elevforhold.getUndervisningsgruppe()
+    public CompletionStage<List<UndervisningsgruppeResource>> getUndervisningsgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(elevforhold.getUndervisningsgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<VurderingResource> getVurdering(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return elevforhold.getVurdering()
+    public CompletionStage<List<VurderingResource>> getVurdering(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(elevforhold.getVurdering()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> vurderingService.getVurderingResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> vurderingService.getVurderingResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<MedlemskapResource> getMedlemskap(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return elevforhold.getMedlemskap()
+    public CompletionStage<List<MedlemskapResource>> getMedlemskap(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(elevforhold.getMedlemskap()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdResolver.java
@@ -3,32 +3,24 @@ package no.fint.graphql.model.utdanning.elevforhold;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-
 import no.fint.graphql.model.utdanning.basisgruppe.BasisgruppeService;
+import no.fint.graphql.model.utdanning.eksamensgruppe.EksamensgruppeService;
 import no.fint.graphql.model.utdanning.elev.ElevService;
 import no.fint.graphql.model.utdanning.elevkategori.ElevkategoriService;
-import no.fint.graphql.model.utdanning.skole.SkoleService;
-import no.fint.graphql.model.utdanning.eksamensgruppe.EksamensgruppeService;
 import no.fint.graphql.model.utdanning.kontaktlarergruppe.KontaktlarergruppeService;
+import no.fint.graphql.model.utdanning.medlemskap.MedlemskapService;
 import no.fint.graphql.model.utdanning.programomrade.ProgramomradeService;
+import no.fint.graphql.model.utdanning.skole.SkoleService;
 import no.fint.graphql.model.utdanning.undervisningsgruppe.UndervisningsgruppeService;
 import no.fint.graphql.model.utdanning.vurdering.VurderingService;
-import no.fint.graphql.model.utdanning.medlemskap.MedlemskapService;
-
-
 import no.fint.model.resource.Link;
-import no.fint.model.resource.utdanning.elev.ElevforholdResource;
-import no.fint.model.resource.utdanning.elev.BasisgruppeResource;
-import no.fint.model.resource.utdanning.elev.ElevResource;
+import no.fint.model.resource.utdanning.elev.*;
 import no.fint.model.resource.utdanning.kodeverk.ElevkategoriResource;
+import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResource;
+import no.fint.model.resource.utdanning.utdanningsprogram.ProgramomradeResource;
 import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
 import no.fint.model.resource.utdanning.vurdering.EksamensgruppeResource;
-import no.fint.model.resource.utdanning.elev.KontaktlarergruppeResource;
-import no.fint.model.resource.utdanning.utdanningsprogram.ProgramomradeResource;
-import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResource;
 import no.fint.model.resource.utdanning.vurdering.VurderingResource;
-import no.fint.model.resource.utdanning.elev.MedlemskapResource;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
@@ -102,13 +94,14 @@ public class ElevforholdResolver implements GraphQLResolver<ElevforholdResource>
                 .findFirst().orElse(null);
     }
 
-    public SkoleResource getSkole(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
-        return elevforhold.getSkole()
+    public CompletionStage<SkoleResource> getSkole(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(elevforhold.getSkole()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> skoleService.getSkoleResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> skoleService.getSkoleResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
     public List<EksamensgruppeResource> getEksamensgruppe(ElevforholdResource elevforhold, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdResolver.java
@@ -87,7 +87,7 @@ public class ElevforholdResolver implements GraphQLResolver<ElevforholdResource>
                 .map(Link::getHref)
                 .map(l -> elevService.getElevResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -97,7 +97,7 @@ public class ElevforholdResolver implements GraphQLResolver<ElevforholdResource>
                 .map(Link::getHref)
                 .map(l -> elevkategoriService.getElevkategoriResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -107,7 +107,7 @@ public class ElevforholdResolver implements GraphQLResolver<ElevforholdResource>
                 .map(Link::getHref)
                 .map(l -> skoleService.getSkoleResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -137,7 +137,7 @@ public class ElevforholdResolver implements GraphQLResolver<ElevforholdResource>
                 .map(Link::getHref)
                 .map(l -> programomradeService.getProgramomradeResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdService.java
@@ -29,7 +29,7 @@ public class ElevforholdService {
     }
 
     public Mono<ElevforholdResource> getElevforholdResource(String url, DataFetchingEnvironment dfe) {
-        return webClientRequest.getMono(url, ElevforholdResource.class, dfe);
+        return webClientRequest.get(url, ElevforholdResource.class, dfe);
     }
 }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elevforhold/ElevforholdService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.elev.ElevforholdResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningElevforholdService")
 public class ElevforholdService {
@@ -17,7 +18,7 @@ public class ElevforholdService {
     @Autowired
     private Endpoints endpoints;
 
-    public ElevforholdResource getElevforholdResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<ElevforholdResource> getElevforholdResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getElevforholdResource(
             endpoints.getUtdanningElev() 
                 + "/elevforhold/" 
@@ -27,8 +28,8 @@ public class ElevforholdService {
             dfe);
     }
 
-    public ElevforholdResource getElevforholdResource(String url, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(url, ElevforholdResource.class, dfe);
+    public Mono<ElevforholdResource> getElevforholdResource(String url, DataFetchingEnvironment dfe) {
+        return webClientRequest.getMono(url, ElevforholdResource.class, dfe);
     }
 }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/elevkategori/ElevkategoriQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elevkategori/ElevkategoriQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.kodeverk.ElevkategoriResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningElevkategoriQueryResolver")
 public class ElevkategoriQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class ElevkategoriQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ElevkategoriService service;
 
-    public ElevkategoriResource getElevkategori(
+    public CompletionStage<ElevkategoriResource> getElevkategori(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getElevkategoriResourceById("systemid", systemId, dfe);
+            return service.getElevkategoriResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<ElevkategoriResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/elevkategori/ElevkategoriService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/elevkategori/ElevkategoriService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.kodeverk.ElevkategoriResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningElevkategoriService")
 public class ElevkategoriService {
@@ -17,7 +18,7 @@ public class ElevkategoriService {
     @Autowired
     private Endpoints endpoints;
 
-    public ElevkategoriResource getElevkategoriResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<ElevkategoriResource> getElevkategoriResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getElevkategoriResource(
             endpoints.getUtdanningKodeverk() 
                 + "/elevkategori/" 
@@ -27,7 +28,7 @@ public class ElevkategoriService {
             dfe);
     }
 
-    public ElevkategoriResource getElevkategoriResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<ElevkategoriResource> getElevkategoriResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, ElevkategoriResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/fag/FagQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/fag/FagQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.timeplan.FagResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningFagQueryResolver")
 public class FagQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class FagQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private FagService service;
 
-    public FagResource getFag(
+    public CompletionStage<FagResource> getFag(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getFagResourceById("systemid", systemId, dfe);
+            return service.getFagResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<FagResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/fag/FagResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/fag/FagResolver.java
@@ -25,9 +25,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 @Component("utdanningFagResolver")
 public class FagResolver implements GraphQLResolver<FagResource> {
@@ -48,13 +46,14 @@ public class FagResolver implements GraphQLResolver<FagResource> {
     private MedlemskapService medlemskapService;
 
 
-    public List<ProgramomradeResource> getProgramomrade(FagResource fag, DataFetchingEnvironment dfe) {
-        return fag.getProgramomrade()
+    public CompletionStage<List<ProgramomradeResource>> getProgramomrade(FagResource fag, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fag.getProgramomrade()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> programomradeService.getProgramomradeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> programomradeService.getProgramomradeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
     public CompletionStage<List<SkoleResource>> getSkole(FagResource fag, DataFetchingEnvironment dfe) {
@@ -67,31 +66,34 @@ public class FagResolver implements GraphQLResolver<FagResource> {
                 .toFuture();
     }
 
-    public List<UndervisningsgruppeResource> getUndervisningsgruppe(FagResource fag, DataFetchingEnvironment dfe) {
-        return fag.getUndervisningsgruppe()
+    public CompletionStage<List<UndervisningsgruppeResource>> getUndervisningsgruppe(FagResource fag, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fag.getUndervisningsgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<EksamensgruppeResource> getEksamensgruppe(FagResource fag, DataFetchingEnvironment dfe) {
-        return fag.getEksamensgruppe()
+    public CompletionStage<List<EksamensgruppeResource>> getEksamensgruppe(FagResource fag, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fag.getEksamensgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<MedlemskapResource> getMedlemskap(FagResource fag, DataFetchingEnvironment dfe) {
-        return fag.getMedlemskap()
+    public CompletionStage<List<MedlemskapResource>> getMedlemskap(FagResource fag, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(fag.getMedlemskap()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/fag/FagService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/fag/FagService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.timeplan.FagResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningFagService")
 public class FagService {
@@ -17,7 +18,7 @@ public class FagService {
     @Autowired
     private Endpoints endpoints;
 
-    public FagResource getFagResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<FagResource> getFagResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getFagResource(
             endpoints.getUtdanningTimeplan() 
                 + "/fag/" 
@@ -27,7 +28,7 @@ public class FagService {
             dfe);
     }
 
-    public FagResource getFagResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<FagResource> getFagResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, FagResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/karakterskala/KarakterskalaQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/karakterskala/KarakterskalaQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.kodeverk.KarakterskalaResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningKarakterskalaQueryResolver")
 public class KarakterskalaQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class KarakterskalaQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private KarakterskalaService service;
 
-    public KarakterskalaResource getKarakterskala(
+    public CompletionStage<KarakterskalaResource> getKarakterskala(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getKarakterskalaResourceById("systemid", systemId, dfe);
+            return service.getKarakterskalaResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<KarakterskalaResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/karakterskala/KarakterskalaService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/karakterskala/KarakterskalaService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.kodeverk.KarakterskalaResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningKarakterskalaService")
 public class KarakterskalaService {
@@ -17,7 +18,7 @@ public class KarakterskalaService {
     @Autowired
     private Endpoints endpoints;
 
-    public KarakterskalaResource getKarakterskalaResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<KarakterskalaResource> getKarakterskalaResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getKarakterskalaResource(
             endpoints.getUtdanningKodeverk() 
                 + "/karakterskala/" 
@@ -27,7 +28,7 @@ public class KarakterskalaService {
             dfe);
     }
 
-    public KarakterskalaResource getKarakterskalaResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<KarakterskalaResource> getKarakterskalaResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, KarakterskalaResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/karakterverdi/KarakterverdiQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/karakterverdi/KarakterverdiQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.vurdering.KarakterverdiResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningKarakterverdiQueryResolver")
 public class KarakterverdiQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class KarakterverdiQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private KarakterverdiService service;
 
-    public KarakterverdiResource getKarakterverdi(
+    public CompletionStage<KarakterverdiResource> getKarakterverdi(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getKarakterverdiResourceById("systemid", systemId, dfe);
+            return service.getKarakterverdiResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<KarakterverdiResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/karakterverdi/KarakterverdiResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/karakterverdi/KarakterverdiResolver.java
@@ -32,7 +32,7 @@ public class KarakterverdiResolver implements GraphQLResolver<KarakterverdiResou
                 .map(Link::getHref)
                 .map(l -> karakterskalaService.getKarakterskalaResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/karakterverdi/KarakterverdiService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/karakterverdi/KarakterverdiService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.vurdering.KarakterverdiResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningKarakterverdiService")
 public class KarakterverdiService {
@@ -17,7 +18,7 @@ public class KarakterverdiService {
     @Autowired
     private Endpoints endpoints;
 
-    public KarakterverdiResource getKarakterverdiResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<KarakterverdiResource> getKarakterverdiResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getKarakterverdiResource(
             endpoints.getUtdanningVurdering() 
                 + "/karakterverdi/" 
@@ -27,7 +28,7 @@ public class KarakterverdiService {
             dfe);
     }
 
-    public KarakterverdiResource getKarakterverdiResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<KarakterverdiResource> getKarakterverdiResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, KarakterverdiResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.elev.KontaktlarergruppeResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningKontaktlarergruppeQueryResolver")
 public class KontaktlarergruppeQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class KontaktlarergruppeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private KontaktlarergruppeService service;
 
-    public KontaktlarergruppeResource getKontaktlarergruppe(
+    public CompletionStage<KontaktlarergruppeResource> getKontaktlarergruppe(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getKontaktlarergruppeResourceById("systemid", systemId, dfe);
+            return service.getKontaktlarergruppeResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<KontaktlarergruppeResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeResolver.java
@@ -21,6 +21,8 @@ import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Objects;
@@ -64,12 +66,13 @@ public class KontaktlarergruppeResolver implements GraphQLResolver<Kontaktlarerg
     }
 
     public List<ElevforholdResource> getElevforhold(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
-        return kontaktlarergruppe.getElevforhold()
+        return Flux.fromStream(kontaktlarergruppe.getElevforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> elevforholdService.getElevforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> elevforholdService.getElevforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .block();
     }
 
     public List<UndervisningsforholdResource> getUndervisningsforhold(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeResolver.java
@@ -25,9 +25,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 @Component("utdanningKontaktlarergruppeResolver")
 public class KontaktlarergruppeResolver implements GraphQLResolver<KontaktlarergruppeResource> {
@@ -48,13 +46,14 @@ public class KontaktlarergruppeResolver implements GraphQLResolver<Kontaktlarerg
     private MedlemskapService medlemskapService;
 
 
-    public List<BasisgruppeResource> getBasisgruppe(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
-        return kontaktlarergruppe.getBasisgruppe()
+    public CompletionStage<List<BasisgruppeResource>> getBasisgruppe(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontaktlarergruppe.getBasisgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
     public CompletionStage<SkoleResource> getSkole(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
@@ -67,32 +66,34 @@ public class KontaktlarergruppeResolver implements GraphQLResolver<Kontaktlarerg
                 .toFuture();
     }
 
-    public List<ElevforholdResource> getElevforhold(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
+    public CompletionStage<List<ElevforholdResource>> getElevforhold(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
         return Flux.fromStream(kontaktlarergruppe.getElevforhold()
                 .stream()
                 .map(Link::getHref)
                 .map(l -> elevforholdService.getElevforholdResource(l, dfe)))
                 .flatMap(Mono::flux)
                 .collectList()
-                .block();
+                .toFuture();
     }
 
-    public List<UndervisningsforholdResource> getUndervisningsforhold(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
-        return kontaktlarergruppe.getUndervisningsforhold()
+    public CompletionStage<List<UndervisningsforholdResource>> getUndervisningsforhold(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontaktlarergruppe.getUndervisningsforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<MedlemskapResource> getMedlemskap(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
-        return kontaktlarergruppe.getMedlemskap()
+    public CompletionStage<List<MedlemskapResource>> getMedlemskap(KontaktlarergruppeResource kontaktlarergruppe, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(kontaktlarergruppe.getMedlemskap()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeResolver.java
@@ -62,7 +62,7 @@ public class KontaktlarergruppeResolver implements GraphQLResolver<Kontaktlarerg
                 .map(Link::getHref)
                 .map(l -> skoleService.getSkoleResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/kontaktlarergruppe/KontaktlarergruppeService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.elev.KontaktlarergruppeResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningKontaktlarergruppeService")
 public class KontaktlarergruppeService {
@@ -17,7 +18,7 @@ public class KontaktlarergruppeService {
     @Autowired
     private Endpoints endpoints;
 
-    public KontaktlarergruppeResource getKontaktlarergruppeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<KontaktlarergruppeResource> getKontaktlarergruppeResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getKontaktlarergruppeResource(
             endpoints.getUtdanningElev() 
                 + "/kontaktlarergruppe/" 
@@ -27,7 +28,7 @@ public class KontaktlarergruppeService {
             dfe);
     }
 
-    public KontaktlarergruppeResource getKontaktlarergruppeResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<KontaktlarergruppeResource> getKontaktlarergruppeResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, KontaktlarergruppeResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/medlemskap/MedlemskapQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/medlemskap/MedlemskapQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningMedlemskapQueryResolver")
 public class MedlemskapQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class MedlemskapQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private MedlemskapService service;
 
-    public MedlemskapResource getMedlemskap(
+    public CompletionStage<MedlemskapResource> getMedlemskap(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getMedlemskapResourceById("systemid", systemId, dfe);
+            return service.getMedlemskapResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<MedlemskapResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/medlemskap/MedlemskapResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/medlemskap/MedlemskapResolver.java
@@ -42,7 +42,7 @@ public class MedlemskapResolver implements GraphQLResolver<MedlemskapResource> {
                 .map(Link::getHref)
                 .map(l -> vurderingService.getVurderingResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/medlemskap/MedlemskapService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/medlemskap/MedlemskapService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningMedlemskapService")
 public class MedlemskapService {
@@ -17,7 +18,7 @@ public class MedlemskapService {
     @Autowired
     private Endpoints endpoints;
 
-    public MedlemskapResource getMedlemskapResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<MedlemskapResource> getMedlemskapResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getMedlemskapResource(
             endpoints.getUtdanningElev() 
                 + "/medlemskap/" 
@@ -27,7 +28,7 @@ public class MedlemskapService {
             dfe);
     }
 
-    public MedlemskapResource getMedlemskapResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<MedlemskapResource> getMedlemskapResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, MedlemskapResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.utdanningsprogram.ProgramomradeResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningProgramomradeQueryResolver")
 public class ProgramomradeQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class ProgramomradeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private ProgramomradeService service;
 
-    public ProgramomradeResource getProgramomrade(
+    public CompletionStage<ProgramomradeResource> getProgramomrade(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getProgramomradeResourceById("systemid", systemId, dfe);
+            return service.getProgramomradeResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<ProgramomradeResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeResolver.java
@@ -21,6 +21,8 @@ import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Objects;
@@ -55,12 +57,13 @@ public class ProgramomradeResolver implements GraphQLResolver<ProgramomradeResou
     }
 
     public List<ElevforholdResource> getElevforhold(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
-        return programomrade.getElevforhold()
+        return Flux.fromStream(programomrade.getElevforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> elevforholdService.getElevforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> elevforholdService.getElevforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .block();
     }
 
     public List<FagResource> getFag(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeResolver.java
@@ -52,7 +52,7 @@ public class ProgramomradeResolver implements GraphQLResolver<ProgramomradeResou
                 .map(Link::getHref)
                 .map(l -> utdanningsprogramService.getUtdanningsprogramResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeResolver.java
@@ -25,8 +25,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningProgramomradeResolver")
 public class ProgramomradeResolver implements GraphQLResolver<ProgramomradeResource> {
@@ -47,50 +46,54 @@ public class ProgramomradeResolver implements GraphQLResolver<ProgramomradeResou
     private MedlemskapService medlemskapService;
 
 
-    public UtdanningsprogramResource getUtdanningsprogram(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
-        return programomrade.getUtdanningsprogram()
+    public CompletionStage<UtdanningsprogramResource> getUtdanningsprogram(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(programomrade.getUtdanningsprogram()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> utdanningsprogramService.getUtdanningsprogramResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> utdanningsprogramService.getUtdanningsprogramResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public List<ElevforholdResource> getElevforhold(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
+    public CompletionStage<List<ElevforholdResource>> getElevforhold(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
         return Flux.fromStream(programomrade.getElevforhold()
                 .stream()
                 .map(Link::getHref)
                 .map(l -> elevforholdService.getElevforholdResource(l, dfe)))
                 .flatMap(Mono::flux)
                 .collectList()
-                .block();
+                .toFuture();
     }
 
-    public List<FagResource> getFag(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
-        return programomrade.getFag()
+    public CompletionStage<List<FagResource>> getFag(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(programomrade.getFag()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> fagService.getFagResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> fagService.getFagResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<ArstrinnResource> getTrinn(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
-        return programomrade.getTrinn()
+    public CompletionStage<List<ArstrinnResource>> getTrinn(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(programomrade.getTrinn()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> arstrinnService.getArstrinnResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> arstrinnService.getArstrinnResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<MedlemskapResource> getMedlemskap(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
-        return programomrade.getMedlemskap()
+    public CompletionStage<List<MedlemskapResource>> getMedlemskap(ProgramomradeResource programomrade, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(programomrade.getMedlemskap()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/programomrade/ProgramomradeService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.utdanningsprogram.ProgramomradeResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningProgramomradeService")
 public class ProgramomradeService {
@@ -17,7 +18,7 @@ public class ProgramomradeService {
     @Autowired
     private Endpoints endpoints;
 
-    public ProgramomradeResource getProgramomradeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<ProgramomradeResource> getProgramomradeResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getProgramomradeResource(
             endpoints.getUtdanningUtdanningsprogram() 
                 + "/programomrade/" 
@@ -27,7 +28,7 @@ public class ProgramomradeService {
             dfe);
     }
 
-    public ProgramomradeResource getProgramomradeResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<ProgramomradeResource> getProgramomradeResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, ProgramomradeResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/rom/RomQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/rom/RomQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.timeplan.RomResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningRomQueryResolver")
 public class RomQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class RomQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private RomService service;
 
-    public RomResource getRom(
+    public CompletionStage<RomResource> getRom(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getRomResourceById("systemid", systemId, dfe);
+            return service.getRomResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<RomResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/rom/RomService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/rom/RomService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.timeplan.RomResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningRomService")
 public class RomService {
@@ -17,7 +18,7 @@ public class RomService {
     @Autowired
     private Endpoints endpoints;
 
-    public RomResource getRomResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<RomResource> getRomResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getRomResource(
             endpoints.getUtdanningTimeplan() 
                 + "/rom/" 
@@ -27,7 +28,7 @@ public class RomService {
             dfe);
     }
 
-    public RomResource getRomResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<RomResource> getRomResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, RomResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningSkoleQueryResolver")
 public class SkoleQueryResolver implements GraphQLQueryResolver {
@@ -14,20 +17,20 @@ public class SkoleQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private SkoleService service;
 
-    public SkoleResource getSkole(
+    public CompletionStage<SkoleResource> getSkole(
             String skolenummer,
             String systemId,
             String organisasjonsnummer,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(skolenummer)) {
-            return service.getSkoleResourceById("skolenummer", skolenummer, dfe);
+            return service.getSkoleResourceById("skolenummer", skolenummer, dfe).toFuture();
         }
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getSkoleResourceById("systemid", systemId, dfe);
+            return service.getSkoleResourceById("systemid", systemId, dfe).toFuture();
         }
         if (StringUtils.isNotEmpty(organisasjonsnummer)) {
-            return service.getSkoleResourceById("organisasjonsnummer", organisasjonsnummer, dfe);
+            return service.getSkoleResourceById("organisasjonsnummer", organisasjonsnummer, dfe).toFuture();
         }
-        return null;
+        return Mono.<SkoleResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleResolver.java
@@ -82,7 +82,7 @@ public class SkoleResolver implements GraphQLResolver<SkoleResource> {
                 .map(Link::getHref)
                 .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -102,7 +102,7 @@ public class SkoleResolver implements GraphQLResolver<SkoleResource> {
                 .map(Link::getHref)
                 .map(l -> skoleeiertypeService.getSkoleeiertypeResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleResolver.java
@@ -37,9 +37,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 @Component("utdanningSkoleResolver")
 public class SkoleResolver implements GraphQLResolver<SkoleResource> {
@@ -78,40 +76,44 @@ public class SkoleResolver implements GraphQLResolver<SkoleResource> {
     private UtdanningsprogramService utdanningsprogramService;
 
 
-    public OrganisasjonselementResource getOrganisasjon(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return skole.getOrganisasjon()
+    public CompletionStage<OrganisasjonselementResource> getOrganisasjon(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(skole.getOrganisasjon()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> organisasjonselementService.getOrganisasjonselementResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public List<FagResource> getFag(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return skole.getFag()
+    public CompletionStage<List<FagResource>> getFag(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(skole.getFag()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> fagService.getFagResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> fagService.getFagResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public SkoleeiertypeResource getSkoleeierType(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return skole.getSkoleeierType()
+    public CompletionStage<SkoleeiertypeResource> getSkoleeierType(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(skole.getSkoleeierType()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> skoleeiertypeService.getSkoleeiertypeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> skoleeiertypeService.getSkoleeiertypeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public List<BasisgruppeResource> getBasisgruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return skole.getBasisgruppe()
+    public CompletionStage<List<BasisgruppeResource>> getBasisgruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(skole.getBasisgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
     public CompletionStage<List<ElevforholdResource>> getElevforhold(SkoleResource skole, DataFetchingEnvironment dfe) {
@@ -120,63 +122,68 @@ public class SkoleResolver implements GraphQLResolver<SkoleResource> {
                 .map(Link::getHref)
                 .map(l -> elevforholdService.getElevforholdResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .filter(Objects::nonNull)
                 .collectList()
                 .toFuture();
     }
 
-    public List<KontaktlarergruppeResource> getKontaktlarergruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return skole.getKontaktlarergruppe()
+    public CompletionStage<List<KontaktlarergruppeResource>> getKontaktlarergruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(skole.getKontaktlarergruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<SkoleressursResource> getSkoleressurs(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return skole.getSkoleressurs()
+    public CompletionStage<List<SkoleressursResource>> getSkoleressurs(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(skole.getSkoleressurs()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> skoleressursService.getSkoleressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> skoleressursService.getSkoleressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<UndervisningsforholdResource> getUndervisningsforhold(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return skole.getUndervisningsforhold()
+    public CompletionStage<List<UndervisningsforholdResource>> getUndervisningsforhold(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(skole.getUndervisningsforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<UndervisningsgruppeResource> getUndervisningsgruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return skole.getUndervisningsgruppe()
+    public CompletionStage<List<UndervisningsgruppeResource>> getUndervisningsgruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(skole.getUndervisningsgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<EksamensgruppeResource> getEksamensgruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return skole.getEksamensgruppe()
+    public CompletionStage<List<EksamensgruppeResource>> getEksamensgruppe(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(skole.getEksamensgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<UtdanningsprogramResource> getUtdanningsprogram(SkoleResource skole, DataFetchingEnvironment dfe) {
-        return skole.getUtdanningsprogram()
+    public CompletionStage<List<UtdanningsprogramResource>> getUtdanningsprogram(SkoleResource skole, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(skole.getUtdanningsprogram()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> utdanningsprogramService.getUtdanningsprogramResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> utdanningsprogramService.getUtdanningsprogramResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.utdanningsprogram.SkoleResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningSkoleService")
 public class SkoleService {
@@ -17,7 +18,7 @@ public class SkoleService {
     @Autowired
     private Endpoints endpoints;
 
-    public SkoleResource getSkoleResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<SkoleResource> getSkoleResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getSkoleResource(
             endpoints.getUtdanningUtdanningsprogram() 
                 + "/skole/" 
@@ -27,8 +28,8 @@ public class SkoleService {
             dfe);
     }
 
-    public SkoleResource getSkoleResource(String url, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(url, SkoleResource.class, dfe);
+    public Mono<SkoleResource> getSkoleResource(String url, DataFetchingEnvironment dfe) {
+        return webClientRequest.getMono(url, SkoleResource.class, dfe);
     }
 }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skole/SkoleService.java
@@ -29,7 +29,7 @@ public class SkoleService {
     }
 
     public Mono<SkoleResource> getSkoleResource(String url, DataFetchingEnvironment dfe) {
-        return webClientRequest.getMono(url, SkoleResource.class, dfe);
+        return webClientRequest.get(url, SkoleResource.class, dfe);
     }
 }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/skoleeiertype/SkoleeiertypeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skoleeiertype/SkoleeiertypeQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.kodeverk.SkoleeiertypeResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningSkoleeiertypeQueryResolver")
 public class SkoleeiertypeQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class SkoleeiertypeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private SkoleeiertypeService service;
 
-    public SkoleeiertypeResource getSkoleeiertype(
+    public CompletionStage<SkoleeiertypeResource> getSkoleeiertype(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getSkoleeiertypeResourceById("systemid", systemId, dfe);
+            return service.getSkoleeiertypeResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<SkoleeiertypeResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/skoleeiertype/SkoleeiertypeService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skoleeiertype/SkoleeiertypeService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.kodeverk.SkoleeiertypeResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningSkoleeiertypeService")
 public class SkoleeiertypeService {
@@ -17,7 +18,7 @@ public class SkoleeiertypeService {
     @Autowired
     private Endpoints endpoints;
 
-    public SkoleeiertypeResource getSkoleeiertypeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<SkoleeiertypeResource> getSkoleeiertypeResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getSkoleeiertypeResource(
             endpoints.getUtdanningKodeverk() 
                 + "/skoleeiertype/" 
@@ -27,7 +28,7 @@ public class SkoleeiertypeService {
             dfe);
     }
 
-    public SkoleeiertypeResource getSkoleeiertypeResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<SkoleeiertypeResource> getSkoleeiertypeResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, SkoleeiertypeResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/skoleressurs/SkoleressursQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skoleressurs/SkoleressursQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.elev.SkoleressursResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningSkoleressursQueryResolver")
 public class SkoleressursQueryResolver implements GraphQLQueryResolver {
@@ -14,16 +17,16 @@ public class SkoleressursQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private SkoleressursService service;
 
-    public SkoleressursResource getSkoleressurs(
+    public CompletionStage<SkoleressursResource> getSkoleressurs(
             String feidenavn,
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(feidenavn)) {
-            return service.getSkoleressursResourceById("feidenavn", feidenavn, dfe);
+            return service.getSkoleressursResourceById("feidenavn", feidenavn, dfe).toFuture();
         }
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getSkoleressursResourceById("systemid", systemId, dfe);
+            return service.getSkoleressursResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<SkoleressursResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/skoleressurs/SkoleressursResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skoleressurs/SkoleressursResolver.java
@@ -42,7 +42,7 @@ public class SkoleressursResolver implements GraphQLResolver<SkoleressursResourc
                 .map(Link::getHref)
                 .map(l -> personalressursService.getPersonalressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/skoleressurs/SkoleressursService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/skoleressurs/SkoleressursService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.elev.SkoleressursResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningSkoleressursService")
 public class SkoleressursService {
@@ -17,7 +18,7 @@ public class SkoleressursService {
     @Autowired
     private Endpoints endpoints;
 
-    public SkoleressursResource getSkoleressursResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<SkoleressursResource> getSkoleressursResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getSkoleressursResource(
             endpoints.getUtdanningElev() 
                 + "/skoleressurs/" 
@@ -27,7 +28,7 @@ public class SkoleressursService {
             dfe);
     }
 
-    public SkoleressursResource getSkoleressursResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<SkoleressursResource> getSkoleressursResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, SkoleressursResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/time/TimeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/time/TimeQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.timeplan.TimeResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningTimeQueryResolver")
 public class TimeQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class TimeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private TimeService service;
 
-    public TimeResource getTime(
+    public CompletionStage<TimeResource> getTime(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getTimeResourceById("systemid", systemId, dfe);
+            return service.getTimeResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<TimeResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/time/TimeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/time/TimeResolver.java
@@ -17,10 +17,11 @@ import no.fint.model.resource.utdanning.timeplan.RomResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningTimeResolver")
 public class TimeResolver implements GraphQLResolver<TimeResource> {
@@ -35,31 +36,34 @@ public class TimeResolver implements GraphQLResolver<TimeResource> {
     private RomService romService;
 
 
-    public List<UndervisningsgruppeResource> getUndervisningsgruppe(TimeResource time, DataFetchingEnvironment dfe) {
-        return time.getUndervisningsgruppe()
+    public CompletionStage<List<UndervisningsgruppeResource>> getUndervisningsgruppe(TimeResource time, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(time.getUndervisningsgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<UndervisningsforholdResource> getUndervisningsforhold(TimeResource time, DataFetchingEnvironment dfe) {
-        return time.getUndervisningsforhold()
+    public CompletionStage<List<UndervisningsforholdResource>> getUndervisningsforhold(TimeResource time, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(time.getUndervisningsforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<RomResource> getRom(TimeResource time, DataFetchingEnvironment dfe) {
-        return time.getRom()
+    public CompletionStage<List<RomResource>> getRom(TimeResource time, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(time.getRom()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> romService.getRomResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> romService.getRomResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/time/TimeService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/time/TimeService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.timeplan.TimeResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningTimeService")
 public class TimeService {
@@ -17,7 +18,7 @@ public class TimeService {
     @Autowired
     private Endpoints endpoints;
 
-    public TimeResource getTimeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<TimeResource> getTimeResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getTimeResource(
             endpoints.getUtdanningTimeplan() 
                 + "/time/" 
@@ -27,7 +28,7 @@ public class TimeService {
             dfe);
     }
 
-    public TimeResource getTimeResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<TimeResource> getTimeResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, TimeResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.elev.UndervisningsforholdResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningUndervisningsforholdQueryResolver")
 public class UndervisningsforholdQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class UndervisningsforholdQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private UndervisningsforholdService service;
 
-    public UndervisningsforholdResource getUndervisningsforhold(
+    public CompletionStage<UndervisningsforholdResource> getUndervisningsforhold(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getUndervisningsforholdResourceById("systemid", systemId, dfe);
+            return service.getUndervisningsforholdResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<UndervisningsforholdResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdResolver.java
@@ -72,7 +72,7 @@ public class UndervisningsforholdResolver implements GraphQLResolver<Undervisnin
                 .map(Link::getHref)
                 .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -132,7 +132,7 @@ public class UndervisningsforholdResolver implements GraphQLResolver<Undervisnin
                 .map(Link::getHref)
                 .map(l -> skoleService.getSkoleResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -142,7 +142,7 @@ public class UndervisningsforholdResolver implements GraphQLResolver<Undervisnin
                 .map(Link::getHref)
                 .map(l -> skoleressursService.getSkoleressursResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdResolver.java
@@ -33,9 +33,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 @Component("utdanningUndervisningsforholdResolver")
 public class UndervisningsforholdResolver implements GraphQLResolver<UndervisningsforholdResource> {
@@ -68,58 +66,64 @@ public class UndervisningsforholdResolver implements GraphQLResolver<Undervisnin
     private MedlemskapService medlemskapService;
 
 
-    public ArbeidsforholdResource getArbeidsforhold(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return undervisningsforhold.getArbeidsforhold()
+    public CompletionStage<ArbeidsforholdResource> getArbeidsforhold(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(undervisningsforhold.getArbeidsforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> arbeidsforholdService.getArbeidsforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public List<BasisgruppeResource> getBasisgruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return undervisningsforhold.getBasisgruppe()
+    public CompletionStage<List<BasisgruppeResource>> getBasisgruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(undervisningsforhold.getBasisgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> basisgruppeService.getBasisgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<KontaktlarergruppeResource> getKontaktlarergruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return undervisningsforhold.getKontaktlarergruppe()
+    public CompletionStage<List<KontaktlarergruppeResource>> getKontaktlarergruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(undervisningsforhold.getKontaktlarergruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> kontaktlarergruppeService.getKontaktlarergruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<UndervisningsgruppeResource> getUndervisningsgruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return undervisningsforhold.getUndervisningsgruppe()
+    public CompletionStage<List<UndervisningsgruppeResource>> getUndervisningsgruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(undervisningsforhold.getUndervisningsgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<EksamensgruppeResource> getEksamensgruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return undervisningsforhold.getEksamensgruppe()
+    public CompletionStage<List<EksamensgruppeResource>> getEksamensgruppe(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(undervisningsforhold.getEksamensgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<TimeResource> getTime(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return undervisningsforhold.getTime()
+    public CompletionStage<List<TimeResource>> getTime(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(undervisningsforhold.getTime()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> timeService.getTimeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> timeService.getTimeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
     public CompletionStage<SkoleResource> getSkole(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
@@ -132,22 +136,24 @@ public class UndervisningsforholdResolver implements GraphQLResolver<Undervisnin
                 .toFuture();
     }
 
-    public SkoleressursResource getSkoleressurs(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return undervisningsforhold.getSkoleressurs()
+    public CompletionStage<SkoleressursResource> getSkoleressurs(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(undervisningsforhold.getSkoleressurs()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> skoleressursService.getSkoleressursResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> skoleressursService.getSkoleressursResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public List<MedlemskapResource> getMedlemskap(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
-        return undervisningsforhold.getMedlemskap()
+    public CompletionStage<List<MedlemskapResource>> getMedlemskap(UndervisningsforholdResource undervisningsforhold, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(undervisningsforhold.getMedlemskap()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsforhold/UndervisningsforholdService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.elev.UndervisningsforholdResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningUndervisningsforholdService")
 public class UndervisningsforholdService {
@@ -17,7 +18,7 @@ public class UndervisningsforholdService {
     @Autowired
     private Endpoints endpoints;
 
-    public UndervisningsforholdResource getUndervisningsforholdResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<UndervisningsforholdResource> getUndervisningsforholdResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getUndervisningsforholdResource(
             endpoints.getUtdanningElev() 
                 + "/undervisningsforhold/" 
@@ -27,7 +28,7 @@ public class UndervisningsforholdService {
             dfe);
     }
 
-    public UndervisningsforholdResource getUndervisningsforholdResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<UndervisningsforholdResource> getUndervisningsforholdResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, UndervisningsforholdResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningUndervisningsgruppeQueryResolver")
 public class UndervisningsgruppeQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class UndervisningsgruppeQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private UndervisningsgruppeService service;
 
-    public UndervisningsgruppeResource getUndervisningsgruppe(
+    public CompletionStage<UndervisningsgruppeResource> getUndervisningsgruppe(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getUndervisningsgruppeResourceById("systemid", systemId, dfe);
+            return service.getUndervisningsgruppeResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<UndervisningsgruppeResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeResolver.java
@@ -67,7 +67,7 @@ public class UndervisningsgruppeResolver implements GraphQLResolver<Undervisning
                 .map(Link::getHref)
                 .map(l -> skoleService.getSkoleResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeResolver.java
@@ -27,9 +27,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 @Component("utdanningUndervisningsgruppeResolver")
 public class UndervisningsgruppeResolver implements GraphQLResolver<UndervisningsgruppeResource> {
@@ -53,13 +51,14 @@ public class UndervisningsgruppeResolver implements GraphQLResolver<Undervisning
     private MedlemskapService medlemskapService;
 
 
-    public List<FagResource> getFag(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
-        return undervisningsgruppe.getFag()
+    public CompletionStage<List<FagResource>> getFag(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(undervisningsgruppe.getFag()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> fagService.getFagResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> fagService.getFagResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
     public CompletionStage<SkoleResource> getSkole(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
@@ -72,41 +71,44 @@ public class UndervisningsgruppeResolver implements GraphQLResolver<Undervisning
                 .toFuture();
     }
 
-    public List<ElevforholdResource> getElevforhold(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
+    public CompletionStage<List<ElevforholdResource>> getElevforhold(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
         return Flux.fromStream(undervisningsgruppe.getElevforhold()
                 .stream()
                 .map(Link::getHref)
                 .map(l -> elevforholdService.getElevforholdResource(l, dfe)))
                 .flatMap(Mono::flux)
                 .collectList()
-                .block();
+                .toFuture();
     }
 
-    public List<UndervisningsforholdResource> getUndervisningsforhold(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
-        return undervisningsgruppe.getUndervisningsforhold()
+    public CompletionStage<List<UndervisningsforholdResource>> getUndervisningsforhold(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(undervisningsgruppe.getUndervisningsforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> undervisningsforholdService.getUndervisningsforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<TimeResource> getTime(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
-        return undervisningsgruppe.getTime()
+    public CompletionStage<List<TimeResource>> getTime(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(undervisningsgruppe.getTime()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> timeService.getTimeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> timeService.getTimeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<MedlemskapResource> getMedlemskap(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
-        return undervisningsgruppe.getMedlemskap()
+    public CompletionStage<List<MedlemskapResource>> getMedlemskap(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(undervisningsgruppe.getMedlemskap()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeResolver.java
@@ -23,6 +23,8 @@ import no.fint.model.resource.utdanning.elev.MedlemskapResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Objects;
@@ -69,12 +71,13 @@ public class UndervisningsgruppeResolver implements GraphQLResolver<Undervisning
     }
 
     public List<ElevforholdResource> getElevforhold(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {
-        return undervisningsgruppe.getElevforhold()
+        return Flux.fromStream(undervisningsgruppe.getElevforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> elevforholdService.getElevforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> elevforholdService.getElevforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .block();
     }
 
     public List<UndervisningsforholdResource> getUndervisningsforhold(UndervisningsgruppeResource undervisningsgruppe, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/undervisningsgruppe/UndervisningsgruppeService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.timeplan.UndervisningsgruppeResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningUndervisningsgruppeService")
 public class UndervisningsgruppeService {
@@ -17,7 +18,7 @@ public class UndervisningsgruppeService {
     @Autowired
     private Endpoints endpoints;
 
-    public UndervisningsgruppeResource getUndervisningsgruppeResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<UndervisningsgruppeResource> getUndervisningsgruppeResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getUndervisningsgruppeResource(
             endpoints.getUtdanningTimeplan() 
                 + "/undervisningsgruppe/" 
@@ -27,7 +28,7 @@ public class UndervisningsgruppeService {
             dfe);
     }
 
-    public UndervisningsgruppeResource getUndervisningsgruppeResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<UndervisningsgruppeResource> getUndervisningsgruppeResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, UndervisningsgruppeResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/utdanningsprogram/UtdanningsprogramQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/utdanningsprogram/UtdanningsprogramQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.utdanningsprogram.UtdanningsprogramResou
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningUtdanningsprogramQueryResolver")
 public class UtdanningsprogramQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class UtdanningsprogramQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private UtdanningsprogramService service;
 
-    public UtdanningsprogramResource getUtdanningsprogram(
+    public CompletionStage<UtdanningsprogramResource> getUtdanningsprogram(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getUtdanningsprogramResourceById("systemid", systemId, dfe);
+            return service.getUtdanningsprogramResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<UtdanningsprogramResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/utdanningsprogram/UtdanningsprogramResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/utdanningsprogram/UtdanningsprogramResolver.java
@@ -21,9 +21,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 @Component("utdanningUtdanningsprogramResolver")
 public class UtdanningsprogramResolver implements GraphQLResolver<UtdanningsprogramResource> {
@@ -48,22 +46,24 @@ public class UtdanningsprogramResolver implements GraphQLResolver<Utdanningsprog
                 .toFuture();
     }
 
-    public List<ProgramomradeResource> getProgramomrade(UtdanningsprogramResource utdanningsprogram, DataFetchingEnvironment dfe) {
-        return utdanningsprogram.getProgramomrade()
+    public CompletionStage<List<ProgramomradeResource>> getProgramomrade(UtdanningsprogramResource utdanningsprogram, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(utdanningsprogram.getProgramomrade()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> programomradeService.getProgramomradeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> programomradeService.getProgramomradeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
-    public List<MedlemskapResource> getMedlemskap(UtdanningsprogramResource utdanningsprogram, DataFetchingEnvironment dfe) {
-        return utdanningsprogram.getMedlemskap()
+    public CompletionStage<List<MedlemskapResource>> getMedlemskap(UtdanningsprogramResource utdanningsprogram, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(utdanningsprogram.getMedlemskap()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> medlemskapService.getMedlemskapResource(l, dfe))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(l -> medlemskapService.getMedlemskapResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .collectList()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/utdanningsprogram/UtdanningsprogramService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/utdanningsprogram/UtdanningsprogramService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.utdanningsprogram.UtdanningsprogramResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningUtdanningsprogramService")
 public class UtdanningsprogramService {
@@ -17,7 +18,7 @@ public class UtdanningsprogramService {
     @Autowired
     private Endpoints endpoints;
 
-    public UtdanningsprogramResource getUtdanningsprogramResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<UtdanningsprogramResource> getUtdanningsprogramResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getUtdanningsprogramResource(
             endpoints.getUtdanningUtdanningsprogram() 
                 + "/utdanningsprogram/" 
@@ -27,7 +28,7 @@ public class UtdanningsprogramService {
             dfe);
     }
 
-    public UtdanningsprogramResource getUtdanningsprogramResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<UtdanningsprogramResource> getUtdanningsprogramResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, UtdanningsprogramResource.class, dfe);
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingQueryResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingQueryResolver.java
@@ -7,6 +7,9 @@ import no.fint.model.resource.utdanning.vurdering.VurderingResource;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningVurderingQueryResolver")
 public class VurderingQueryResolver implements GraphQLQueryResolver {
@@ -14,12 +17,12 @@ public class VurderingQueryResolver implements GraphQLQueryResolver {
     @Autowired
     private VurderingService service;
 
-    public VurderingResource getVurdering(
+    public CompletionStage<VurderingResource> getVurdering(
             String systemId,
             DataFetchingEnvironment dfe) {
         if (StringUtils.isNotEmpty(systemId)) {
-            return service.getVurderingResourceById("systemid", systemId, dfe);
+            return service.getVurderingResourceById("systemid", systemId, dfe).toFuture();
         }
-        return null;
+        return Mono.<VurderingResource>empty().toFuture();
     }
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingResolver.java
@@ -23,8 +23,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletionStage;
 
 @Component("utdanningVurderingResolver")
 public class VurderingResolver implements GraphQLResolver<VurderingResource> {
@@ -42,40 +41,44 @@ public class VurderingResolver implements GraphQLResolver<VurderingResource> {
     private KarakterverdiService karakterverdiService;
 
 
-    public ElevforholdResource getElevforhold(VurderingResource vurdering, DataFetchingEnvironment dfe) {
+    public CompletionStage<ElevforholdResource> getElevforhold(VurderingResource vurdering, DataFetchingEnvironment dfe) {
         return Flux.fromStream(vurdering.getElevforhold()
                 .stream()
                 .map(Link::getHref)
                 .map(l -> elevforholdService.getElevforholdResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .blockFirst();
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public UndervisningsgruppeResource getUndervisningsgruppe(VurderingResource vurdering, DataFetchingEnvironment dfe) {
-        return vurdering.getUndervisningsgruppe()
+    public CompletionStage<UndervisningsgruppeResource> getUndervisningsgruppe(VurderingResource vurdering, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(vurdering.getUndervisningsgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public EksamensgruppeResource getEksamensgruppe(VurderingResource vurdering, DataFetchingEnvironment dfe) {
-        return vurdering.getEksamensgruppe()
+    public CompletionStage<EksamensgruppeResource> getEksamensgruppe(VurderingResource vurdering, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(vurdering.getEksamensgruppe()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
-    public KarakterverdiResource getKarakter(VurderingResource vurdering, DataFetchingEnvironment dfe) {
-        return vurdering.getKarakter()
+    public CompletionStage<KarakterverdiResource> getKarakter(VurderingResource vurdering, DataFetchingEnvironment dfe) {
+        return Flux.fromStream(vurdering.getKarakter()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> karakterverdiService.getKarakterverdiResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> karakterverdiService.getKarakterverdiResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .singleOrEmpty()
+                .toFuture();
     }
 
 }

--- a/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingResolver.java
@@ -47,7 +47,7 @@ public class VurderingResolver implements GraphQLResolver<VurderingResource> {
                 .map(Link::getHref)
                 .map(l -> elevforholdService.getElevforholdResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -57,7 +57,7 @@ public class VurderingResolver implements GraphQLResolver<VurderingResource> {
                 .map(Link::getHref)
                 .map(l -> undervisningsgruppeService.getUndervisningsgruppeResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -67,7 +67,7 @@ public class VurderingResolver implements GraphQLResolver<VurderingResource> {
                 .map(Link::getHref)
                 .map(l -> eksamensgruppeService.getEksamensgruppeResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 
@@ -77,7 +77,7 @@ public class VurderingResolver implements GraphQLResolver<VurderingResource> {
                 .map(Link::getHref)
                 .map(l -> karakterverdiService.getKarakterverdiResource(l, dfe)))
                 .flatMap(Mono::flux)
-                .singleOrEmpty()
+                .next()
                 .toFuture();
     }
 

--- a/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingResolver.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingResolver.java
@@ -19,6 +19,8 @@ import no.fint.model.resource.utdanning.vurdering.KarakterverdiResource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Objects;
@@ -41,12 +43,12 @@ public class VurderingResolver implements GraphQLResolver<VurderingResource> {
 
 
     public ElevforholdResource getElevforhold(VurderingResource vurdering, DataFetchingEnvironment dfe) {
-        return vurdering.getElevforhold()
+        return Flux.fromStream(vurdering.getElevforhold()
                 .stream()
                 .map(Link::getHref)
-                .map(l -> elevforholdService.getElevforholdResource(l, dfe))
-                .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .map(l -> elevforholdService.getElevforholdResource(l, dfe)))
+                .flatMap(Mono::flux)
+                .blockFirst();
     }
 
     public UndervisningsgruppeResource getUndervisningsgruppe(VurderingResource vurdering, DataFetchingEnvironment dfe) {

--- a/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingService.java
+++ b/src/main/java/no/fint/graphql/model/utdanning/vurdering/VurderingService.java
@@ -7,6 +7,7 @@ import no.fint.graphql.model.Endpoints;
 import no.fint.model.resource.utdanning.vurdering.VurderingResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service("utdanningVurderingService")
 public class VurderingService {
@@ -17,7 +18,7 @@ public class VurderingService {
     @Autowired
     private Endpoints endpoints;
 
-    public VurderingResource getVurderingResourceById(String id, String value, DataFetchingEnvironment dfe) {
+    public Mono<VurderingResource> getVurderingResourceById(String id, String value, DataFetchingEnvironment dfe) {
         return getVurderingResource(
             endpoints.getUtdanningVurdering() 
                 + "/vurdering/" 
@@ -27,7 +28,7 @@ public class VurderingService {
             dfe);
     }
 
-    public VurderingResource getVurderingResource(String url, DataFetchingEnvironment dfe) {
+    public Mono<VurderingResource> getVurderingResource(String url, DataFetchingEnvironment dfe) {
         return webClientRequest.get(url, VurderingResource.class, dfe);
     }
 }

--- a/src/main/resources/schema/administrasjon/aktivitet.graphqls
+++ b/src/main/resources/schema/administrasjon/aktivitet.graphqls
@@ -1,0 +1,13 @@
+
+type Aktivitet {
+
+	# Inherited Attributes
+    gyldighetsperiode: Periode # Begrep
+    kode: String! # Begrep
+    navn: String! # Begrep
+    passiv: Boolean # Begrep
+    systemId: Identifikator! # Begrep
+
+	# Relations
+    fullmakt: [Fullmakt]
+}

--- a/src/main/resources/schema/administrasjon/anlegg.graphqls
+++ b/src/main/resources/schema/administrasjon/anlegg.graphqls
@@ -1,0 +1,13 @@
+
+type Anlegg {
+
+	# Inherited Attributes
+    gyldighetsperiode: Periode # Begrep
+    kode: String! # Begrep
+    navn: String! # Begrep
+    passiv: Boolean # Begrep
+    systemId: Identifikator! # Begrep
+
+	# Relations
+    fullmakt: [Fullmakt]
+}

--- a/src/main/resources/schema/administrasjon/arbeidsforhold.graphqls
+++ b/src/main/resources/schema/administrasjon/arbeidsforhold.graphqls
@@ -2,6 +2,7 @@
 type Arbeidsforhold {
 	#  Attributes
     ansettelsesprosent: Long!
+    arslonn: Long!
     gyldighetsperiode: Periode!
     hovedstilling: Boolean!
     lonnsprosent: Long!
@@ -9,7 +10,6 @@ type Arbeidsforhold {
     stillingstittel: String
     systemId: Identifikator!
     tilstedeprosent: Long!
-    arslonn: Long!
 
 
 	# Relations

--- a/src/main/resources/schema/administrasjon/diverse.graphqls
+++ b/src/main/resources/schema/administrasjon/diverse.graphqls
@@ -1,0 +1,13 @@
+
+type Diverse {
+
+	# Inherited Attributes
+    gyldighetsperiode: Periode # Begrep
+    kode: String! # Begrep
+    navn: String! # Begrep
+    passiv: Boolean # Begrep
+    systemId: Identifikator! # Begrep
+
+	# Relations
+    fullmakt: [Fullmakt]
+}

--- a/src/main/resources/schema/administrasjon/fastlonn.graphqls
+++ b/src/main/resources/schema/administrasjon/fastlonn.graphqls
@@ -7,6 +7,7 @@ type Fastlonn {
     anvist: Date # Lonn
     attestert: Date # Lonn
     beskrivelse: String! # Lonn
+    kildesystemId: Identifikator # Lonn
     kontert: Date # Lonn
     kontostreng: Kontostreng! # Lonn
     opptjent: Periode # Lonn

--- a/src/main/resources/schema/administrasjon/fasttillegg.graphqls
+++ b/src/main/resources/schema/administrasjon/fasttillegg.graphqls
@@ -7,6 +7,7 @@ type Fasttillegg {
     anvist: Date # Lonn
     attestert: Date # Lonn
     beskrivelse: String! # Lonn
+    kildesystemId: Identifikator # Lonn
     kontert: Date # Lonn
     kontostreng: Kontostreng! # Lonn
     opptjent: Periode # Lonn

--- a/src/main/resources/schema/administrasjon/kontostreng.graphqls
+++ b/src/main/resources/schema/administrasjon/kontostreng.graphqls
@@ -3,8 +3,15 @@ type Kontostreng {
 
 
 	# Relations
+    aktivitet: Aktivitet
+    anlegg: Anlegg
     ansvar: Ansvar!
     art: Art!
+    diverse: Diverse
     funksjon: Funksjon!
+    kontrakt: Kontrakt
+    lopenummer: Lopenummer
+    objekt: Objekt
     prosjekt: Prosjekt
+    ramme: Ramme
 }

--- a/src/main/resources/schema/administrasjon/kontrakt.graphqls
+++ b/src/main/resources/schema/administrasjon/kontrakt.graphqls
@@ -1,0 +1,13 @@
+
+type Kontrakt {
+
+	# Inherited Attributes
+    gyldighetsperiode: Periode # Begrep
+    kode: String! # Begrep
+    navn: String! # Begrep
+    passiv: Boolean # Begrep
+    systemId: Identifikator! # Begrep
+
+	# Relations
+    fullmakt: [Fullmakt]
+}

--- a/src/main/resources/schema/administrasjon/lopenummer.graphqls
+++ b/src/main/resources/schema/administrasjon/lopenummer.graphqls
@@ -1,0 +1,13 @@
+
+type Lopenummer {
+
+	# Inherited Attributes
+    gyldighetsperiode: Periode # Begrep
+    kode: String! # Begrep
+    navn: String! # Begrep
+    passiv: Boolean # Begrep
+    systemId: Identifikator! # Begrep
+
+	# Relations
+    fullmakt: [Fullmakt]
+}

--- a/src/main/resources/schema/administrasjon/objekt.graphqls
+++ b/src/main/resources/schema/administrasjon/objekt.graphqls
@@ -1,0 +1,13 @@
+
+type Objekt {
+
+	# Inherited Attributes
+    gyldighetsperiode: Periode # Begrep
+    kode: String! # Begrep
+    navn: String! # Begrep
+    passiv: Boolean # Begrep
+    systemId: Identifikator! # Begrep
+
+	# Relations
+    fullmakt: [Fullmakt]
+}

--- a/src/main/resources/schema/administrasjon/ramme.graphqls
+++ b/src/main/resources/schema/administrasjon/ramme.graphqls
@@ -1,0 +1,13 @@
+
+type Ramme {
+
+	# Inherited Attributes
+    gyldighetsperiode: Periode # Begrep
+    kode: String! # Begrep
+    navn: String! # Begrep
+    passiv: Boolean # Begrep
+    systemId: Identifikator! # Begrep
+
+	# Relations
+    fullmakt: [Fullmakt]
+}

--- a/src/main/resources/schema/administrasjon/variabellonn.graphqls
+++ b/src/main/resources/schema/administrasjon/variabellonn.graphqls
@@ -8,6 +8,7 @@ type Variabellonn {
     anvist: Date # Lonn
     attestert: Date # Lonn
     beskrivelse: String! # Lonn
+    kildesystemId: Identifikator # Lonn
     kontert: Date # Lonn
     kontostreng: Kontostreng! # Lonn
     opptjent: Periode # Lonn

--- a/src/main/resources/schema/root.graphqls
+++ b/src/main/resources/schema/root.graphqls
@@ -10,8 +10,6 @@ type Query {
 	elev(brukernavn: String, elevnummer: String, feidenavn: String, systemId: String): Elev
 	elevforhold(systemId: String): Elevforhold
 	fag(systemId: String): Fag
-	fastlonn(systemId: String): Fastlonn
-	fasttillegg(systemId: String): Fasttillegg
 	fullmakt(systemId: String): Fullmakt
 	karakterverdi(systemId: String): Karakterverdi
 	kontaktlarergruppe(systemId: String): Kontaktlarergruppe
@@ -29,6 +27,5 @@ type Query {
 	undervisningsforhold(systemId: String): Undervisningsforhold
 	undervisningsgruppe(systemId: String): Undervisningsgruppe
 	utdanningsprogram(systemId: String): Utdanningsprogram
-	variabellonn(systemId: String): Variabellonn
 	vurdering(systemId: String): Vurdering
 }

--- a/src/test/groovy/no/fint/graphql/WebClientRequestSpec.groovy
+++ b/src/test/groovy/no/fint/graphql/WebClientRequestSpec.groovy
@@ -24,7 +24,7 @@ class WebClientRequestSpec extends Specification {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("response"))
 
         when:
-        def response = webClientRequest.get(url, String, dfe)
+        def response = webClientRequest.get(url, String, dfe).block()
         def request = server.takeRequest()
 
         then:
@@ -38,7 +38,7 @@ class WebClientRequestSpec extends Specification {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("response"))
 
         when:
-        def response = webClientRequest.get(url, String, dfe)
+        def response = webClientRequest.get(url, String, dfe).block()
         def request = server.takeRequest()
 
         then:

--- a/src/test/groovy/no/fint/graphql/WebClientRequestSpec.groovy
+++ b/src/test/groovy/no/fint/graphql/WebClientRequestSpec.groovy
@@ -1,8 +1,8 @@
 package no.fint.graphql
 
-import graphql.execution.ExecutionContext
+
 import graphql.schema.DataFetchingEnvironment
-import graphql.servlet.GraphQLContext
+import graphql.servlet.context.GraphQLServletContext
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.springframework.http.HttpHeaders
@@ -48,11 +48,9 @@ class WebClientRequestSpec extends Specification {
 
     private DataFetchingEnvironment createDataFetchingEnvironmentMock(String token = null) {
         Mock(DataFetchingEnvironment) {
-            getExecutionContext() >> Mock(ExecutionContext) {
-                getContext() >> Mock(GraphQLContext) {
-                    getHttpServletRequest() >> Optional.of(Mock(HttpServletRequest) {
-                        if (token != null) getHeader(HttpHeaders.AUTHORIZATION) >> token
-                    })
+            getContext() >> Mock(GraphQLServletContext) {
+                getHttpServletRequest() >> Mock(HttpServletRequest) {
+                    if (token != null) getHeader(HttpHeaders.AUTHORIZATION) >> token
                 }
             }
         }


### PR DESCRIPTION
Regenerated using `Mono` + `Flux` and `CompletionStage` to enable parallel / asynchronous fetch of resources.

Closes #12 
Fixes #11 (I hope, might need to configure connections to be recycled after some time)

Generated with FINTLabs/fint-graphql-cli#4