### PR TITLE
Cache requests matching kodeverk URIs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.2.4.RELEASE'
+        springBootVersion = '2.2.7.RELEASE'
     }
     repositories {
         jcenter()
@@ -47,9 +47,12 @@ dependencies {
     compile('com.graphql-java-kickstart:graphiql-spring-boot-starter:6.0.1')
     compile('com.graphql-java-kickstart:graphql-java-tools:5.7.1')
     compile('com.zhokhov.graphql:graphql-datetime-spring-boot-starter:1.6.0')
+    compile('io.projectreactor.addons:reactor-extra')
+    compile('com.github.ben-manes.caffeine:caffeine')
 
     compile('org.springframework.boot:spring-boot-starter-webflux')
     compile('org.springframework.boot:spring-boot-starter')
+    compileOnly('org.springframework.boot:spring-boot-configuration-processor')
     compileOnly("org.projectlombok:lombok:${lombokVersion}")
 
     runtime('org.springframework.boot:spring-boot-starter-actuator')

--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     compile('com.graphql-java-kickstart:graphiql-spring-boot-starter:6.0.1')
     compile('com.graphql-java-kickstart:graphql-java-tools:5.7.1')
     compile('com.zhokhov.graphql:graphql-datetime-spring-boot-starter:1.6.0')
-    compile('io.projectreactor.addons:reactor-extra')
     compile('com.github.ben-manes.caffeine:caffeine')
+    compile('io.projectreactor.addons:reactor-extra')
 
     compile('org.springframework.boot:spring-boot-starter-webflux')
     compile('org.springframework.boot:spring-boot-starter')

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ dependencies {
     compile('com.graphql-java-kickstart:graphiql-spring-boot-starter:6.0.1')
     compile('com.graphql-java-kickstart:graphql-java-tools:5.7.1')
     compile('com.zhokhov.graphql:graphql-datetime-spring-boot-starter:1.6.0')
-    compile('io.projectreactor.addons:reactor-extra')
     compile('com.github.ben-manes.caffeine:caffeine')
 
     compile('org.springframework.boot:spring-boot-starter-webflux')

--- a/generate.sh
+++ b/generate.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 docker run \
-  -v ${PWD}/src/main/resources/schema:/src/graphql/schema \
-  -v ${PWD}/src/main/java/no/fint/graphql/model:/src/graphql/model \
-  fint/graphql-cli:1.1.0 \
+  -v "${PWD}/src/main/resources/schema:/src/graphql/schema" \
+  -v "${PWD}/src/main/java/no/fint/graphql/model:/src/graphql/model" \
+  fint/graphql-cli:latest \
   generate --exclude Fravar
 
 echo Schema and models generated.  Please remember to clean up ${PWD}/src/main/{resources/schema,java/no/fint/graphql/model} before commit.

--- a/src/main/java/no/fint/graphql/WebClientRequest.java
+++ b/src/main/java/no/fint/graphql/WebClientRequest.java
@@ -1,13 +1,21 @@
 package no.fint.graphql;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.base.Charsets;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.servlet.context.GraphQLServletContext;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.cache.CacheMono;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
@@ -16,19 +24,35 @@ import java.time.Duration;
 @Component
 public class WebClientRequest {
 
-    @Autowired
-    private WebClient webClient;
+    private final WebClient webClient;
+    private final Cache<HashCode, Object> cache;
+    private final HashFunction hashFunction;
 
-    public <T> Mono<T> get(String uri, Class<T> type, DataFetchingEnvironment dfe) {
-        return get(webClient.get().uri(uri), type, dfe);
+    public WebClientRequest(
+            WebClient webClient,
+            @Value("${fint.webclient.cache-spec:maximumSize=10000,expireAfterWrite=10m}") String cacheSpec) {
+        this.webClient = webClient;
+        cache = Caffeine.from(cacheSpec).build();
+        hashFunction = Hashing.murmur3_128();
     }
 
-    private <T> Mono<T> get(WebClient.RequestHeadersSpec<?> request, Class<T> type, DataFetchingEnvironment dfe) {
+    public <T> Mono<T> get(String uri, Class<T> type, DataFetchingEnvironment dfe) {
         String token = getToken(dfe);
         log.debug("Token: {}", token);
+        final WebClient.RequestHeadersSpec<?> request = webClient.get().uri(uri);
         if (token != null) {
             request.header(HttpHeaders.AUTHORIZATION, token);
         }
+        if (StringUtils.containsIgnoreCase(uri, "/kodeverk/systemid/")) {
+            HashCode key = hashFunction.newHasher().putString(token, Charsets.UTF_8).putString(uri, Charsets.UTF_8).hash();
+            return CacheMono
+                    .lookup(cache.asMap(), key, type)
+                    .onCacheMissResume(() -> get(request, type));
+        }
+        return get(request, type);
+    }
+
+    private <T> Mono<T> get(WebClient.RequestHeadersSpec<?> request, Class<T> type) {
         return request.retrieve()
                 .onStatus(HttpStatus::is4xxClientError, r -> Mono.empty())
                 .bodyToMono(type)

--- a/src/main/java/no/fint/graphql/WebClientRequest.java
+++ b/src/main/java/no/fint/graphql/WebClientRequest.java
@@ -36,7 +36,6 @@ public class WebClientRequest {
 
     public <T> Mono<T> get(String uri, Class<T> type, DataFetchingEnvironment dfe) {
         String token = getToken(dfe);
-        log.debug("Token: {}", token);
         final WebClient.RequestHeadersSpec<?> request = webClient.get().uri(uri);
         if (token != null) {
             request.header(HttpHeaders.AUTHORIZATION, token);
@@ -45,10 +44,10 @@ public class WebClientRequest {
             HashCode key = hashFunction.newHasher().putUnencodedChars(token).putUnencodedChars(uri).hash();
             final T result = (T) cache.getIfPresent(key);
             if (result != null) {
-                log.info("Cache hit on {}", uri);
+                log.trace("Cache hit on {}", uri);
                 return Mono.just(result);
             }
-            log.info("Cache miss on {}", uri);
+            log.trace("Cache miss on {}", uri);
             return get(request, type)
                     .doOnNext(value -> cache.put(key, value));
         }

--- a/src/main/java/no/fint/graphql/WebClientRequest.java
+++ b/src/main/java/no/fint/graphql/WebClientRequest.java
@@ -43,7 +43,7 @@ public class WebClientRequest {
         if (token != null) {
             request.header(HttpHeaders.AUTHORIZATION, token);
         }
-        if (StringUtils.containsIgnoreCase(uri, "/kodeverk/systemid/")) {
+        if (StringUtils.containsIgnoreCase(uri, "/kodeverk/")) {
             HashCode key = hashFunction.newHasher().putString(token, Charsets.UTF_8).putString(uri, Charsets.UTF_8).hash();
             return CacheMono
                     .lookup(cache.asMap(), key, type)

--- a/src/test/groovy/no/fint/graphql/WebClientRequestSpec.groovy
+++ b/src/test/groovy/no/fint/graphql/WebClientRequestSpec.groovy
@@ -16,7 +16,9 @@ class WebClientRequestSpec extends Specification {
     private MockWebServer server = new MockWebServer()
     private String url = server.url('/').toString()
     private WebClient webClient = WebClient.create(url)
-    private WebClientRequest webClientRequest = new WebClientRequest(webClient: webClient)
+    private WebClientRequest webClientRequest = new WebClientRequest(
+            webClient,
+            'maximumSize=1,expireAfterWrite=1s')
 
     def "Get request with token"() {
         given:


### PR DESCRIPTION
This PR caches all request to URIs matching `/kodeverk/`.  It keys the cache with both the URI and the Bearer token, to ensure that cached valued are not mixed between organizations.