### PR TITLE
Enabled structured logging using net.logstash.logback:logstash-logback-encoder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'com.graphql-java-kickstart:graphql-java-tools:5.7.1'
     implementation 'com.zhokhov.graphql:graphql-datetime-spring-boot-starter:1.6.0'
     implementation 'com.github.ben-manes.caffeine:caffeine'
+    implementation 'net.logstash.logback:logstash-logback-encoder:6.6'
 
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- Include Spring Boot defaults: patterns (CONSOLE_LOG_PATTERN), converters, common loggers -->
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <!-- Optional: Spring props for app metadata in JSON -->
+    <springProperty scope="context" name="appName" source="spring.application.name"/>
+
+    <!-- JSON Console Appender (overrides default CONSOLE) -->
+    <appender name="CONSOLE-JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <!-- Standard fields: timestamp (ISO), level, logger, thread, message -->
+                <timestamp/>
+                <logLevel/>
+                <loggerName fieldName="logger"/>
+                <threadName fieldName="thread"/>
+                <message/>
+                <!-- MDC (e.g., traceId from WebFlux/Sleuth if added) -->
+                <mdc/>
+                <!-- Context: app name, pid -->
+                <contextName/>
+                <version/>
+                <!-- Stack traces (shortened) -->
+                <stackTrace>
+                    <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                        <maxDepthPerThrowable>20</maxDepthPerThrowable>
+                        <rootCauseFirst>true</rootCauseFirst>
+                    </throwableConverter>
+                </stackTrace>
+            </providers>
+        </encoder>
+    </appender>
+
+    <!-- Root logger to JSON console (INFO default; override via application.properties e.g. logging.level.root=DEBUG) -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE-JSON"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Added and enabled structured logging in order to allow logfmt to properly parse log messages