### PR TITLE
refactor: respond with HTTP 401 and GraphQL error body when missing token or blacklisted IP

### DIFF
--- a/src/main/java/no/fint/graphql/BlacklistService.java
+++ b/src/main/java/no/fint/graphql/BlacklistService.java
@@ -20,12 +20,8 @@ public class BlacklistService {
         log.info("Blacklist: {}", blacklist);
     }
 
-    public void failIfBlacklisted(String ip, String bearerToken) {
-        if (StringUtils.isBlank(ip)) return;
-
-        if (blacklist.contains(ip)) {
-            log.info("Cast exception because IP is blacklisted " + bearerToken);
-            throw new RuntimeException("Client is blacklisted: " + ip);
-        }
+    public boolean isBlacklisted(String ip) {
+        if (StringUtils.isBlank(ip)) return false;
+        return blacklist.contains(ip);
     }
 }

--- a/src/main/java/no/fint/graphql/MissingAuthorizationException.java
+++ b/src/main/java/no/fint/graphql/MissingAuthorizationException.java
@@ -1,0 +1,7 @@
+package no.fint.graphql;
+
+public class MissingAuthorizationException extends RuntimeException {
+    public MissingAuthorizationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/no/fint/graphql/WebClientGraphQLErrorHandler.java
+++ b/src/main/java/no/fint/graphql/WebClientGraphQLErrorHandler.java
@@ -53,6 +53,16 @@ public class WebClientGraphQLErrorHandler extends DefaultGraphQLErrorHandler {
             String resourcePath = resourcePath(requestException.getUri());
             return toRemoteFailureError(dataFetchingError, requestException, resourcePath);
         }
+        if (exception instanceof MissingAuthorizationException) {
+            return new RemoteAccessGraphQLError(
+                    "Unauthorized",
+                    error.getLocations(),
+                    error.getPath(),
+                    Map.of(
+                            "code", 401
+                    )
+            );
+        }
 
         log.warn("Unmapped ExceptionWhileDataFetching: {}", error);
         return error;

--- a/src/main/java/no/fint/graphql/config/AuthGraphQLError.java
+++ b/src/main/java/no/fint/graphql/config/AuthGraphQLError.java
@@ -1,0 +1,43 @@
+package no.fint.graphql.config;
+
+import graphql.GraphQLError;
+
+import java.util.List;
+import java.util.Map;
+
+public class AuthGraphQLError implements GraphQLError {
+    private final String message;
+    private final Map<String, Object> extensions;
+
+    public AuthGraphQLError(String message) {
+        this.message = message != null ? message : "Unauthorized";
+        this.extensions = Map.of(
+                "code", 401
+        );
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public List<graphql.language.SourceLocation> getLocations() {
+        return null;
+    }
+
+    @Override
+    public List<Object> getPath() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+
+    @Override
+    public graphql.ErrorClassification getErrorType() {
+        return null;
+    }
+}

--- a/src/main/java/no/fint/graphql/config/GraphQLAuthFilter.java
+++ b/src/main/java/no/fint/graphql/config/GraphQLAuthFilter.java
@@ -1,0 +1,115 @@
+package no.fint.graphql.config;
+
+import graphql.ExecutionResultImpl;
+import graphql.kickstart.execution.GraphQLObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import no.fint.graphql.BlacklistService;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * Guards GraphQL requests by requiring a valid Authorization header and rejecting
+ * blacklisted client IPs with a 401 GraphQL error response.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@Slf4j
+public class GraphQLAuthFilter extends OncePerRequestFilter {
+
+    private final GraphQLObjectMapper graphQLObjectMapper;
+    private final BlacklistService blacklistService;
+
+    public GraphQLAuthFilter(GraphQLObjectMapper graphQLObjectMapper, BlacklistService blacklistService) {
+        this.graphQLObjectMapper = graphQLObjectMapper;
+        this.blacklistService = blacklistService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        if (!isGraphQLRequest(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (blacklistService.isBlacklisted(getRemoteIp(request))) {
+            log.warn("Blacklisted request from {}", getRemoteIp(request));
+            writeUnauthorizedResponse(response);
+            return;
+        } else if (!hasValidJwt(getAuthorization(request))) {
+            log.warn("Request without JWT token from {}", getRemoteIp(request));
+            writeUnauthorizedResponse(response);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isGraphQLRequest(HttpServletRequest request) {
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            return false;
+        }
+        String uri = request.getRequestURI();
+        return uri != null && uri.endsWith("/graphql");
+    }
+
+    private String getAuthorization(HttpServletRequest request) {
+        return request.getHeader(HttpHeaders.AUTHORIZATION);
+    }
+
+    private boolean hasValidJwt(String authorization) {
+        if (StringUtils.isBlank(authorization)) {
+            return false;
+        }
+        if (!authorization.startsWith("Bearer ")) {
+            return false;
+        }
+        String token = authorization.substring("Bearer ".length()).trim();
+        if (token.isEmpty()) {
+            return false;
+        }
+        String[] parts = token.split("\\.");
+        if (parts.length != 3) {
+            return false;
+        }
+        for (String part : parts) {
+            if (StringUtils.isBlank(part)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String getRemoteIp(HttpServletRequest request) {
+        if (request == null) return null;
+        return request.getRemoteAddr();
+    }
+
+    private void writeUnauthorizedResponse(HttpServletResponse response) throws IOException {
+        if (response.isCommitted()) {
+            return;
+        }
+        ExecutionResultImpl result = new ExecutionResultImpl(
+                null,
+                Collections.singletonList(new AuthGraphQLError("Unauthorized"))
+        );
+        String json = graphQLObjectMapper.serializeResultAsJson(result);
+        response.resetBuffer();
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(json);
+        response.getWriter().flush();
+    }
+}

--- a/src/main/java/no/fint/graphql/config/GraphQLAuthStatusFilter.java
+++ b/src/main/java/no/fint/graphql/config/GraphQLAuthStatusFilter.java
@@ -1,0 +1,122 @@
+package no.fint.graphql.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import javax.servlet.AsyncEvent;
+import javax.servlet.AsyncListener;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Rewrites GraphQL HTTP responses to 401 when the payload contains an Unauthorized
+ * GraphQL error produced by auth enforcement deeper in the execution pipeline.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 5)
+public class GraphQLAuthStatusFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    public GraphQLAuthStatusFilter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        if (!isGraphQLRequest(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        ContentCachingResponseWrapper wrapper = new ContentCachingResponseWrapper(response);
+        filterChain.doFilter(request, wrapper);
+
+        if (request.isAsyncStarted()) {
+            request.getAsyncContext().addListener(new AsyncListener() {
+                @Override
+                public void onComplete(AsyncEvent event) throws IOException {
+                    handleResponse(wrapper);
+                }
+
+                @Override
+                public void onTimeout(AsyncEvent event) throws IOException {
+                    handleResponse(wrapper);
+                }
+
+                @Override
+                public void onError(AsyncEvent event) throws IOException {
+                    handleResponse(wrapper);
+                }
+
+                @Override
+                public void onStartAsync(AsyncEvent event) {
+                    // no-op
+                }
+            });
+            return;
+        }
+
+        handleResponse(wrapper);
+    }
+
+    private void handleResponse(ContentCachingResponseWrapper wrapper) throws IOException {
+        if (wrapper.isCommitted()) {
+            return;
+        }
+        byte[] body = wrapper.getContentAsByteArray();
+        if (body.length > 0 && isJson(wrapper.getContentType())) {
+            if (hasAuthError(body)) {
+                wrapper.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            }
+        }
+        wrapper.copyBodyToResponse();
+    }
+
+    private boolean hasAuthError(byte[] body) {
+        try {
+            JsonNode root = objectMapper.readTree(body);
+            JsonNode errors = root.path("errors");
+            if (!errors.isArray()) {
+                return false;
+            }
+            for (JsonNode error : errors) {
+                JsonNode extensions = error.path("extensions");
+                JsonNode code = extensions.path("code");
+                JsonNode message = error.path("message");
+                if (code.isInt() && code.asInt() == 401 && message.isTextual()
+                        && "Unauthorized".equals(message.asText())) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+
+    private boolean isJson(String contentType) {
+        if (contentType == null) {
+            return false;
+        }
+        return MediaType.valueOf(contentType).isCompatibleWith(MediaType.APPLICATION_JSON);
+    }
+
+    private boolean isGraphQLRequest(HttpServletRequest request) {
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            return false;
+        }
+        String uri = request.getRequestURI();
+        return uri != null && uri.endsWith("/graphql");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,5 @@ graphql:
   servlet:
     exception-handlers-enabled: true
     async-mode-enabled: true
+server:
+  forward-headers-strategy: framework

--- a/src/test/groovy/no/fint/graphql/GraphQLAsyncTimeoutSpec.groovy
+++ b/src/test/groovy/no/fint/graphql/GraphQLAsyncTimeoutSpec.groovy
@@ -57,6 +57,7 @@ class GraphQLAsyncTimeoutSpec extends Specification {
                 .build()
                 .post()
                 .uri("/graphql")
+                .header("Authorization", "Bearer header.payload.signature")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue([query: query])
                 .exchange()

--- a/src/test/groovy/no/fint/graphql/GraphQLAuthBlacklistedSpec.groovy
+++ b/src/test/groovy/no/fint/graphql/GraphQLAuthBlacklistedSpec.groovy
@@ -1,0 +1,54 @@
+package no.fint.graphql
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import spock.lang.Specification
+
+import java.time.Duration
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = no.fint.graphql.Application,
+        properties = [
+                "spring.main.allow-bean-definition-overriding=true",
+                "fint.graphql.blacklist=127.0.0.1,::1"
+        ]
+)
+@AutoConfigureWebTestClient
+class GraphQLAuthBlacklistedSpec extends Specification {
+
+    @Autowired
+    private WebTestClient webTestClient
+
+    def "Blacklisted IP returns 401 with GraphQL error body"() {
+        given:
+        def query = 'query { rolle(navn: "foo") { navn { identifikatorverdi } } }'
+
+        when:
+        def responseBody = webTestClient.mutate()
+                .responseTimeout(Duration.ofSeconds(5))
+                .build()
+                .post()
+                .uri("/graphql")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer header.payload.signature")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue([query: query])
+                .exchange()
+                .expectStatus().isUnauthorized()
+                .returnResult(String)
+                .responseBody
+                .blockFirst()
+
+        then:
+        def body = new ObjectMapper().readValue(responseBody, Map)
+        body.data == null
+        body.errors?.size() == 1
+        body.errors[0].extensions?.code == 401
+        body.errors[0].message == "Unauthorized"
+    }
+}

--- a/src/test/groovy/no/fint/graphql/GraphQLAuthMissingHeaderSpec.groovy
+++ b/src/test/groovy/no/fint/graphql/GraphQLAuthMissingHeaderSpec.groovy
@@ -1,0 +1,52 @@
+package no.fint.graphql
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import spock.lang.Specification
+
+import java.time.Duration
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = no.fint.graphql.Application,
+        properties = [
+                "spring.main.allow-bean-definition-overriding=true",
+                "fint.graphql.blacklist="
+        ]
+)
+@AutoConfigureWebTestClient
+class GraphQLAuthMissingHeaderSpec extends Specification {
+
+    @Autowired
+    private WebTestClient webTestClient
+
+    def "Missing Authorization header returns 401 with GraphQL error body"() {
+        given:
+        def query = 'query { rolle(navn: "foo") { navn { identifikatorverdi } } }'
+
+        when:
+        def responseBody = webTestClient.mutate()
+                .responseTimeout(Duration.ofSeconds(5))
+                .build()
+                .post()
+                .uri("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue([query: query])
+                .exchange()
+                .expectStatus().isUnauthorized()
+                .returnResult(String)
+                .responseBody
+                .blockFirst()
+
+        then:
+        def body = new ObjectMapper().readValue(responseBody, Map)
+        body.data == null
+        body.errors?.size() == 1
+        body.errors[0].extensions?.code == 401
+        body.errors[0].message == "Unauthorized"
+    }
+}

--- a/src/test/groovy/no/fint/graphql/GraphQLQueryTimeoutSpec.groovy
+++ b/src/test/groovy/no/fint/graphql/GraphQLQueryTimeoutSpec.groovy
@@ -57,6 +57,7 @@ class GraphQLQueryTimeoutSpec extends Specification {
                 .build()
                 .post()
                 .uri("/graphql")
+                .header("Authorization", "Bearer header.payload.signature")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue([query: query])
                 .exchange()

--- a/src/test/groovy/no/fint/graphql/WebClientGraphQLErrorHandlerIntegrationSpec.groovy
+++ b/src/test/groovy/no/fint/graphql/WebClientGraphQLErrorHandlerIntegrationSpec.groovy
@@ -303,6 +303,7 @@ class WebClientGraphQLErrorHandlerIntegrationSpec extends Specification {
                 .build()
                 .post()
                 .uri("/graphql")
+                .header("Authorization", "Bearer header.payload.signature")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue([query: query])
                 .exchange()

--- a/src/test/groovy/no/fint/graphql/WebClientRequestSpec.groovy
+++ b/src/test/groovy/no/fint/graphql/WebClientRequestSpec.groovy
@@ -50,15 +50,13 @@ class WebClientRequestSpec extends Specification {
     def "Get request without token"() {
         given:
         def dfe = createDataFetchingEnvironmentMock()
-        server.enqueue(new MockResponse().setResponseCode(200).setBody("response"))
 
         when:
-        def response = webClientRequest.get(url, String, dfe).block()
-        def request = server.takeRequest()
+        webClientRequest.get(url, String, dfe).block()
 
         then:
-        response == 'response'
-        !request.getHeader(HttpHeaders.AUTHORIZATION)
+        thrown(MissingAuthorizationException)
+        server.takeRequest(200, TimeUnit.MILLISECONDS) == null
     }
 
     def "Get request returns status #status as WebClientResponseException"() {


### PR DESCRIPTION
Respond with HTTP 401 and GraphQL error body when missing token or blacklisted IP