### PR TITLE
fix: make WebClientRequest#toRequestUri(uri) encode invalid characters in uris (encode spaces to %20)

### DIFF
--- a/src/main/java/no/fint/graphql/WebClientRequest.java
+++ b/src/main/java/no/fint/graphql/WebClientRequest.java
@@ -21,6 +21,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 import reactor.netty.internal.shaded.reactor.pool.PoolAcquirePendingLimitException;
 import reactor.netty.internal.shaded.reactor.pool.PoolAcquireTimeoutException;
@@ -306,7 +307,12 @@ public class WebClientRequest {
         if (StringUtils.isBlank(uri)) {
             return rootUri;
         }
-        URI parsed = URI.create(uri);
+        URI parsed;
+        try {
+            parsed = URI.create(uri);
+        } catch (IllegalArgumentException ex) {
+            parsed = UriComponentsBuilder.fromUriString(uri).build().encode().toUri();
+        }
         if (parsed.isAbsolute()) {
             return rootUri.resolve(toPathAndQuery(parsed));
         }

--- a/src/test/groovy/no/fint/graphql/WebClientRequestSpec.groovy
+++ b/src/test/groovy/no/fint/graphql/WebClientRequestSpec.groovy
@@ -95,6 +95,17 @@ class WebClientRequestSpec extends Specification {
         requestUri == URI.create(url).resolve("${encodedPath}?filter=A%2FB")
     }
 
+    def "toRequestUri encodes invalid characters in an absolute uri"() {
+        given:
+        def uriWithSpace = 'http://felleskomponenter/domain/package/resource/idkey/foo bar'
+
+        when:
+        def requestUri = ReflectionTestUtils.invokeMethod(webClientRequest, 'toRequestUri', uriWithSpace)
+
+        then:
+        requestUri == URI.create(url).resolve('/domain/package/resource/idkey/foo%20bar')
+    }
+
     def "Configured WebClient preserves encoded path and overrides Host header for absolute link"() {
         given:
         def configuredHost = 'beta.example.test'


### PR DESCRIPTION
Avoid spaces in URIs by encoding spaces to %20